### PR TITLE
Add feature overview to dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -30,10 +30,12 @@ import {
   Sparkles,
   TrendingUp,
   Users,
+  MessageSquare,
   FileText,
   Calendar,
 } from "lucide-react";
 import { CreateOrganizationDialog } from "@/components/dashboard/CreateOrganizationDialog";
+import FeatureOverview from "@/components/dashboard/FeatureOverview";
 import AuthPage from "../auth/page";
 
 export default function Dashboard() {
@@ -78,6 +80,24 @@ export default function Dashboard() {
             Créer du contenu
           </a>
         </Button>
+      </div>
+
+      {/* Prospection */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Prospection</CardTitle>
+            <MessageSquare className="h-4 w-4 text-pink-600" />
+          </CardHeader>
+          <CardContent>
+            <Button className="w-full" size="sm" asChild>
+              <a href="/dashboard/prospect/linkedin">
+                <Plus className="mr-2 h-4 w-4" />
+                Démarrer la prospection
+              </a>
+            </Button>
+          </CardContent>
+        </Card>
       </div>
 
       {/* Quick Actions */}
@@ -140,6 +160,9 @@ export default function Dashboard() {
           </CardContent>
         </Card>
       </div>
+
+      {/* Feature Overview */}
+      <FeatureOverview />
 
       {/* Recent Activity */}
       <div className="grid gap-4 md:grid-cols-2">

--- a/app/dashboard/prospect/[type]/[projectId]/page.tsx
+++ b/app/dashboard/prospect/[type]/[projectId]/page.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { databases } from "@/lib/appwrite-config";
+import { ID, Query } from "appwrite";
+import ContentGenerator from "@/components/dashboard/ContentGenerator";
+import { BookDashed, Briefcase, Copy, RefreshCcw, Trash2 } from "lucide-react";
+import { motion } from "framer-motion";
+
+export default function ProspectContentPage() {
+  const { currentOrganization, user } = useAuth();
+  const { type, projectId } = useParams();
+  const [project, setProject] = useState<any>(null);
+  const [existingContents, setExistingContents] = useState<any[]>([]);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [contentToDelete, setContentToDelete] = useState<any>(null);
+  const [confirmationText, setConfirmationText] = useState("");
+
+  useEffect(() => {
+    const fetchProject = async () => {
+      if (!projectId || !currentOrganization) return;
+      const res = await databases.getDocument(
+        process.env.NEXT_PUBLIC_APPWRITE_DATABASE_ID!,
+        process.env.NEXT_PUBLIC_APPWRITE_PROJECTS_COLLECTION_ID!,
+        projectId.toString(),
+      );
+      setProject(res);
+    };
+
+    const fetchContents = async () => {
+      if (!projectId || !currentOrganization) return;
+      const res = await databases.listDocuments(
+        process.env.NEXT_PUBLIC_APPWRITE_DATABASE_ID!,
+        process.env.NEXT_PUBLIC_APPWRITE_CONTENTS_COLLECTION_ID!,
+        [
+          Query.equal("organizationId", currentOrganization.$id),
+          Query.equal("projectId", projectId.toString()),
+          Query.equal("type", type.toString()),
+          Query.orderDesc("createdAt"),
+        ],
+      );
+      setExistingContents(res.documents);
+    };
+
+    fetchProject();
+    fetchContents();
+  }, [projectId, currentOrganization, type]);
+
+  const handleSaveContent = async (content: string) => {
+    if (!currentOrganization || !projectId || !user) return;
+    const topic = content.slice(0, 50);
+    const doc = await databases.createDocument(
+      process.env.NEXT_PUBLIC_APPWRITE_DATABASE_ID!,
+      process.env.NEXT_PUBLIC_APPWRITE_CONTENTS_COLLECTION_ID!,
+      ID.unique(),
+      {
+        organizationId: currentOrganization.$id,
+        projectId: projectId.toString(),
+        userId: user.$id,
+        type: type.toString(),
+        topic,
+        content,
+        createdAt: new Date().toISOString(),
+      },
+    );
+    setExistingContents((prev) => [doc, ...prev]);
+  };
+
+  const handleCopy = async (text: string, id: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopiedId(id);
+    setTimeout(() => setCopiedId(null), 2000);
+  };
+
+  const handleDeleteContent = async () => {
+    if (confirmationText.toLowerCase() !== "supprimer" || !contentToDelete)
+      return;
+
+    try {
+      await databases.deleteDocument(
+        process.env.NEXT_PUBLIC_APPWRITE_DATABASE_ID!,
+        process.env.NEXT_PUBLIC_APPWRITE_CONTENTS_COLLECTION_ID!,
+        contentToDelete.$id,
+      );
+      setExistingContents((prev) =>
+        prev.filter((c) => c.$id !== contentToDelete.$id),
+      );
+      setShowDeleteModal(false);
+      setConfirmationText("");
+      setContentToDelete(null);
+    } catch (error) {
+      console.error("Erreur lors de la suppression :", error);
+    }
+  };
+
+  const orgName = currentOrganization?.name || "Organisation inconnue";
+  const orgDesc =
+    currentOrganization?.description || "Pas de description disponible.";
+  const projectName = project?.name || "Projet inconnu";
+  const projectDesc = project?.description || "Pas de description disponible.";
+
+const fullPrompt = `Contexte :
+- Organisation : ${orgName}
+  Description : ${orgDesc}
+- Projet : ${projectName}
+  Description : ${projectDesc}
+
+Génère un message de prospection ${type} en lien avec ce projet.`;
+
+  return (
+    <motion.div
+      className="flex flex-col gap-6 p-4 sm:p-6 max-w-4xl w-full mx-auto"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
+      <motion.div
+        className="space-y-1"
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        <h1 className="text-2xl font-bold tracking-tight">
+          Générateur de prospection <span className="capitalize">{type}</span>
+        </h1>
+        {project?.name && (
+          <div className="inline-flex items-center gap-2 px-3 py-1 text-sm rounded-full bg-muted text-muted-foreground w-fit">
+            <Briefcase className="w-4 h-4" />
+            {project.name}
+          </div>
+        )}
+        <p className="text-muted-foreground text-sm">
+          Créez, copiez et regénérez facilement vos messages.
+      </p>
+      </motion.div>
+
+      <ContentGenerator
+        type={`prospect-${type}`}
+        title={`Messages de prospection ${type}`}
+        description={fullPrompt}
+        placeholder="Ex: marketing digital, bien-être, IA..."
+        onGenerated={handleSaveContent}
+      />
+      <Separator />
+
+      {existingContents.length > 0 ? (
+        <motion.div
+          className="space-y-4"
+          initial="hidden"
+          animate="visible"
+          variants={{
+            hidden: { opacity: 0 },
+            visible: {
+              opacity: 1,
+              transition: { staggerChildren: 0.05 },
+            },
+          }}
+        >
+          <h2 className="text-xl font-semibold">Messages générés</h2>
+          <div className="grid gap-4">
+            {existingContents.map((item, index) => (
+              <motion.div
+                key={item.$id}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: index * 0.05, duration: 0.3 }}
+              >
+                <Card className="transition-shadow hover:shadow-md">
+                  <CardHeader>
+                    <CardTitle className="text-base">{item.topic}</CardTitle>
+                    <CardDescription className="text-xs text-muted-foreground">
+                      {new Date(item.createdAt).toLocaleString()}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="whitespace-pre-line text-sm">
+                      {item.content}
+                    </p>
+                  </CardContent>
+                  <CardFooter className="flex flex-wrap gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleCopy(item.content, item.$id)}
+                    >
+                      <Copy className="w-4 h-4 mr-1" />
+                      {copiedId === item.$id ? "Copié !" : "Copier"}
+                    </Button>
+
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => {
+                        setContentToDelete(item);
+                        setShowDeleteModal(true);
+                      }}
+                    >
+                      <Trash2 className="w-4 h-4 mr-1" />
+                      Supprimer
+                    </Button>
+                  </CardFooter>
+                </Card>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+      ) : (
+        <div className="flex flex-col items-center justify-center text-center text-muted-foreground py-20">
+          <h3 className="text-lg font-semibold">Aucun message généré</h3>
+          <p className="text-sm mt-1">
+            Utilisez le générateur ci-dessus pour créer votre premier message.
+          </p>
+        </div>
+      )}
+
+      <Dialog open={showDeleteModal} onOpenChange={setShowDeleteModal}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirmer la suppression</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Pour confirmer la suppression, tapez <strong>supprimer</strong>{" "}
+            ci-dessous.
+          </p>
+          <Input
+            placeholder="Tapez 'supprimer'"
+            value={confirmationText}
+            onChange={(e) => setConfirmationText(e.target.value)}
+          />
+          <DialogFooter className="mt-4">
+            <Button variant="outline" onClick={() => setShowDeleteModal(false)}>
+              Annuler
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeleteContent}
+              disabled={confirmationText.toLowerCase() !== "supprimer"}
+            >
+              Supprimer définitivement
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </motion.div>
+  );
+}

--- a/app/dashboard/prospect/[type]/page.tsx
+++ b/app/dashboard/prospect/[type]/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardFooter,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import { databases } from "@/lib/appwrite-config";
+import { Query } from "appwrite";
+import { motion } from "framer-motion";
+
+export default function ProspectProjectSelectorPage() {
+  const { currentOrganization } = useAuth();
+  const { type } = useParams();
+  const [projects, setProjects] = useState<any[]>([]);
+
+  useEffect(() => {
+    const fetchProjects = async () => {
+      if (!currentOrganization) return;
+      try {
+        const res = await databases.listDocuments(
+          process.env.NEXT_PUBLIC_APPWRITE_DATABASE_ID!,
+          process.env.NEXT_PUBLIC_APPWRITE_PROJECTS_COLLECTION_ID!,
+          [Query.equal("organizationId", currentOrganization.$id)],
+        );
+        setProjects(res.documents);
+      } catch (error) {
+        console.error("Erreur lors du chargement des projets :", error);
+      }
+    };
+
+    fetchProjects();
+  }, [currentOrganization]);
+
+  if (!currentOrganization) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            <CardTitle>Prospection {type}</CardTitle>
+            <CardDescription>
+              Veuillez créer une organisation pour commencer.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      className="p-6 space-y-6"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
+      <motion.div
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        <h1 className="text-2xl font-bold">Choisissez un projet</h1>
+        <p className="text-muted-foreground">
+          Sélectionnez un projet pour générer des messages de prospection
+          {" "}
+          {type}.
+        </p>
+      </motion.div>
+
+      <Separator />
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {projects.map((project, index) => (
+          <motion.div
+            key={project.$id}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.05, duration: 0.4 }}
+          >
+            <Card>
+              <CardHeader>
+                <CardTitle>{project.name}</CardTitle>
+                <CardDescription>
+                  {project.description || "Pas de description"}
+                </CardDescription>
+              </CardHeader>
+              <CardFooter>
+                <Button asChild className="w-full">
+                  <Link
+                    href={`/dashboard/prospect/${type}/${project.$id}`}
+                  >
+                    <Plus className="mr-2 h-4 w-4" />
+                    Générer des messages
+                  </Link>
+                </Button>
+              </CardFooter>
+            </Card>
+          </motion.div>
+        ))}
+      </div>
+    </motion.div>
+  );
+}

--- a/components/dashboard/ContentGenerator.tsx
+++ b/components/dashboard/ContentGenerator.tsx
@@ -98,6 +98,9 @@ export default function ContentGenerator({
     const emailTypes = ["email", "newsletter"];
     const isEmail = emailTypes.includes(typeLower);
 
+    // Prospection (messages privés)
+    const isProspect = typeLower.includes("prospect");
+
     // Types d'articles
     const articleTypes = ["article", "blog", "publication"];
     const isArticle = articleTypes.includes(typeLower);
@@ -123,6 +126,16 @@ ${description || "Pas de contexte spécifique fourni."}
 - Optimise pour ${type === "linkedin" ? "un public professionnel" : "l'engagement et la viralité"}
 - Longueur optimale pour la plateforme
 - Pas de balises Markdown, texte brut uniquement
+
+`;
+    } else if (isProspect) {
+      const channel = typeLower.replace("prospect-", "");
+      prompt += `Instructions pour message de prospection ${channel} :
+- Message court et personnalisé
+- Présente la proposition de valeur du projet
+- Termine par un appel à l'action clair
+- Ton professionnel et engageant
+- Pas de hashtags ni de Markdown
 
 `;
     } else if (isEmail) {

--- a/components/dashboard/FeatureOverview.tsx
+++ b/components/dashboard/FeatureOverview.tsx
@@ -1,0 +1,62 @@
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+
+export default function FeatureOverview() {
+  const features = [
+    {
+      emoji: "🎯",
+      title: "Champ de recherche",
+      description: "Saisissez un sujet ou une idée comme point de départ."
+    },
+    {
+      emoji: "📝",
+      title: "Contenu multicanal",
+      description: "Posts LinkedIn, légendes Instagram, tweets et emails courts."
+    },
+    {
+      emoji: "🎨",
+      title: "Carrousel",
+      description: "Slides de carrousel prêts à l'export (texte uniquement)."
+    },
+    {
+      emoji: "✍️",
+      title: "Article de blog",
+      description: "Article complet optimisé pour le SEO."
+    },
+    {
+      emoji: "🧠",
+      title: "Choix du ton",
+      description: "Personnalisez le ton : pro, fun, éducatif ou storytelling."
+    },
+    {
+      emoji: "📤",
+      title: "Export simple",
+      description: "Copiez ou téléchargez immédiatement vos contenus générés."
+    }
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Fonctionnalités clés</CardTitle>
+        <CardDescription>
+          Aperçu des principales fonctions de Postgen AI.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3">
+          {features.map((feature, index) => (
+            <li key={index} className="flex items-start gap-3">
+              <span className="text-xl">{feature.emoji}</span>
+              <div>
+                <p className="font-medium leading-none">{feature.title}</p>
+                <p className="text-sm text-muted-foreground">
+                  {feature.description}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/navigation-data.ts
+++ b/lib/navigation-data.ts
@@ -144,6 +144,28 @@ export const contentCreation: NavigationItem[] = [
     ],
   },
   {
+    title: "Prospection",
+    url: "/dashboard/prospect",
+    icon: MessageSquare,
+    items: [
+      {
+        title: "LinkedIn",
+        url: "/dashboard/prospect/linkedin",
+        icon: MessageSquare,
+      },
+      {
+        title: "Instagram",
+        url: "/dashboard/prospect/instagram",
+        icon: MessageSquare,
+      },
+      {
+        title: "Email",
+        url: "/dashboard/prospect/email",
+        icon: Mail,
+      },
+    ],
+  },
+  {
     title: "Visual Content",
     url: "/dashboard/content/visual",
     icon: ImageIcon,


### PR DESCRIPTION
## Summary
- show main features on the dashboard
- create `FeatureOverview` component
- add prospecting section and generator pages
- extend navigation with prospecting links
- support prospect messages in ContentGenerator

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68607f9e77808323ad968172417b02bb