### PR TITLE
Centralize pricing plan configuration

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -35,6 +35,7 @@ import {
 } from "lucide-react";
 import { CreateOrganizationDialog } from "@/components/dashboard/CreateOrganizationDialog";
 import AuthPage from "../auth/page";
+import { PRICING_PLANS_BY_ID, type PlanId } from "@/lib/plans";
 
 export default function Dashboard() {
   const { user, currentOrganization } = useAuth();
@@ -59,6 +60,8 @@ export default function Dashboard() {
       </AuthGuard>
     );
   }
+
+  const planDetails = PRICING_PLANS_BY_ID[currentOrganization.plan as PlanId];
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
@@ -130,12 +133,10 @@ export default function Dashboard() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold capitalize">
-              {currentOrganization.plan}
+              {planDetails?.name ?? currentOrganization.plan}
             </div>
             <p className="text-xs text-muted-foreground">
-              {currentOrganization.plan === "starter" && "Gratuit"}
-              {currentOrganization.plan === "pro" && "29€/mois"}
-              {currentOrganization.plan === "enterprise" && "99€/mois"}
+              {planDetails?.price ?? "Tarif personnalisé"}
             </p>
           </CardContent>
         </Card>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { PRICING_PLANS } from "@/lib/plans";
 
 const features = [
   {
@@ -57,40 +58,6 @@ const workflow = [
     title: "Publiez, mesurez, itérez",
     description:
       "Planifiez vos publications, analysez les résultats et réutilisez facilement ce qui fonctionne pour booster votre présence.",
-  },
-];
-
-const plans = [
-  {
-    name: "Starter",
-    price: "Gratuit",
-    description: "Idéal pour découvrir Postgen AI et publier vos premiers contenus.",
-    perks: [
-      "Génération de posts illimitée en mode brouillon",
-      "1 organisation et 2 membres inclus",
-      "Bibliothèque de prompts et briefs prêts à l'emploi",
-    ],
-  },
-  {
-    name: "Pro",
-    price: "29€ / mois",
-    description: "Pensé pour les équipes marketing qui publient chaque semaine.",
-    perks: [
-      "Collaborateurs illimités",
-      "Automatisations multi-canales et planification",
-      "Analyses d'engagement et recommandations IA",
-    ],
-    highlight: true,
-  },
-  {
-    name: "Enterprise",
-    price: "Sur mesure",
-    description: "Accompagnement premium pour les marques à forte volumétrie.",
-    perks: [
-      "Support dédié et SLA contractuel",
-      "Espaces sur-mesure et intégrations avancées",
-      "Hébergement souverain et conformité renforcée",
-    ],
   },
 ];
 
@@ -356,9 +323,9 @@ export default function Home() {
               </p>
             </div>
             <div className="mt-12 grid gap-6 lg:grid-cols-3">
-              {plans.map((plan) => (
+              {PRICING_PLANS.map((plan) => (
                 <Card
-                  key={plan.name}
+                  key={plan.id}
                   className={`flex h-full flex-col border ${plan.highlight ? "border-slate-900 shadow-xl shadow-slate-900/10" : "border-border"}`}
                 >
                   <CardHeader>
@@ -377,9 +344,15 @@ export default function Home() {
                         </li>
                       ))}
                     </ul>
-                    {plan.highlight && (
-                      <Button className="mt-8 w-full" asChild>
-                        <Link href="/auth">Choisir le plan Pro</Link>
+                    {plan.cta && (
+                      <Button className="mt-8 w-full" variant={plan.cta.variant} asChild>
+                        {plan.cta.external ? (
+                          <a href={plan.cta.href} target="_blank" rel="noopener noreferrer">
+                            {plan.cta.label}
+                          </a>
+                        ) : (
+                          <Link href={plan.cta.href}>{plan.cta.label}</Link>
+                        )}
                       </Button>
                     )}
                   </CardContent>

--- a/components/dashboard/CreateOrganizationDialog.tsx
+++ b/components/dashboard/CreateOrganizationDialog.tsx
@@ -9,11 +9,12 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Plus, Loader2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
+import { PRICING_PLANS, type PlanId } from "@/lib/plans";
 
 export function CreateOrganizationDialog() {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
-  const [plan, setPlan] = useState<"starter" | "pro" | "enterprise">("starter");
+  const [plan, setPlan] = useState<PlanId>("starter");
   const [loading, setLoading] = useState(false);
   const { createOrganization } = useAuth();
   const { toast } = useToast();
@@ -70,14 +71,16 @@ export function CreateOrganizationDialog() {
           </div>
           <div className="space-y-2">
             <Label htmlFor="org-plan">Plan</Label>
-            <Select value={plan} onValueChange={(value: "starter" | "pro" | "enterprise") => setPlan(value)}>
+            <Select value={plan} onValueChange={(value) => setPlan(value as PlanId)}>
               <SelectTrigger>
                 <SelectValue placeholder="Sélectionner un plan" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="starter">Starter - Gratuit</SelectItem>
-                <SelectItem value="pro">Pro - 29€/mois</SelectItem>
-                <SelectItem value="enterprise">Enterprise - 99€/mois</SelectItem>
+                {PRICING_PLANS.map((planOption) => (
+                  <SelectItem key={planOption.id} value={planOption.id}>
+                    {planOption.name} - {planOption.price}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -1,0 +1,73 @@
+export type PlanId = "starter" | "pro" | "enterprise";
+
+export interface PlanCTA {
+  label: string;
+  href: string;
+  variant?: "default" | "secondary" | "destructive" | "outline" | "ghost" | "link";
+  external?: boolean;
+}
+
+export interface PlanDefinition {
+  id: PlanId;
+  name: string;
+  description: string;
+  price: string;
+  perks: string[];
+  highlight?: boolean;
+  cta?: PlanCTA;
+}
+
+export const PRICING_PLANS: PlanDefinition[] = [
+  {
+    id: "starter",
+    name: "Starter",
+    price: "Gratuit",
+    description: "Idéal pour découvrir Postgen AI et publier vos premiers contenus.",
+    perks: [
+      "Génération de posts illimitée en mode brouillon",
+      "1 organisation et 2 membres inclus",
+      "Bibliothèque de prompts et briefs prêts à l'emploi",
+    ],
+  },
+  {
+    id: "pro",
+    name: "Pro",
+    price: "29€ / mois",
+    description: "Pensé pour les équipes marketing qui publient chaque semaine.",
+    perks: [
+      "Collaborateurs illimités",
+      "Automatisations multi-canales et planification",
+      "Analyses d'engagement et recommandations IA",
+    ],
+    highlight: true,
+    cta: {
+      label: "Choisir le plan Pro",
+      href: "/auth",
+    },
+  },
+  {
+    id: "enterprise",
+    name: "Enterprise",
+    price: "Sur mesure",
+    description: "Accompagnement premium pour les marques à forte volumétrie.",
+    perks: [
+      "Support dédié et SLA contractuel",
+      "Espaces sur-mesure et intégrations avancées",
+      "Hébergement souverain et conformité renforcée",
+    ],
+    cta: {
+      label: "Planifier une démo",
+      href: "mailto:hello@postgen.ai",
+      variant: "outline",
+      external: true,
+    },
+  },
+];
+
+export const PRICING_PLANS_BY_ID: Record<PlanId, PlanDefinition> = PRICING_PLANS.reduce(
+  (acc, plan) => {
+    acc[plan.id] = plan;
+    return acc;
+  },
+  {} as Record<PlanId, PlanDefinition>,
+);


### PR DESCRIPTION
## Summary
- add a shared pricing plan module with names, descriptions, prices, and CTA metadata
- update the landing page pricing section to consume the shared configuration and expose custom CTAs
- align the create-organization dialog and dashboard plan card with the shared pricing data for consistent enterprise messaging

## Testing
- pnpm lint *(fails: ESLint is not installed in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fa34a0388323b5970bc6a85cbce2