### PR TITLE
Add Appwrite-backed team management to settings pages

### DIFF
--- a/hooks/useOrganizationMembers.ts
+++ b/hooks/useOrganizationMembers.ts
@@ -1,0 +1,140 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Models } from "appwrite";
+
+import { authService, Organization } from "@/lib/auth";
+import { getPlanLimit } from "@/lib/plans";
+
+type Options = {
+  onTeamResolved?: (teamId: string) => void | Promise<void>;
+};
+
+export function useOrganizationMembers(
+  organization?: Organization | null,
+  options?: Options,
+) {
+  const [teamId, setTeamId] = useState<string | null>(organization?.teamId ?? null);
+  const [members, setMembers] = useState<Models.Membership[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setTeamId(organization?.teamId ?? null);
+  }, [organization?.teamId]);
+
+  const ensureTeam = useCallback(async () => {
+    if (!organization) {
+      throw new Error("Organisation introuvable");
+    }
+
+    if (teamId) {
+      return teamId;
+    }
+
+    const createdTeamId = await authService.ensureOrganizationTeam(
+      organization.$id,
+      organization.name,
+    );
+    setTeamId(createdTeamId);
+    await options?.onTeamResolved?.(createdTeamId);
+    return createdTeamId;
+  }, [organization, options, teamId]);
+
+  const fetchMembers = useCallback(async () => {
+    if (!organization) {
+      setMembers([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const resolvedTeamId = await ensureTeam();
+      const { memberships } = await authService.listTeamMembers(resolvedTeamId);
+      setMembers(memberships);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Erreur inconnue";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [ensureTeam, organization]);
+
+  useEffect(() => {
+    fetchMembers();
+  }, [fetchMembers]);
+
+  const limit = useMemo(() => {
+    if (!organization) return null;
+    return getPlanLimit(organization.plan);
+  }, [organization]);
+
+  const isAtLimit = useMemo(() => {
+    if (limit === null) {
+      return false;
+    }
+
+    return members.length >= limit;
+  }, [limit, members.length]);
+
+  const inviteMember = useCallback(
+    async (email: string, role: string = "member", name?: string) => {
+      if (!organization) {
+        throw new Error("Organisation introuvable");
+      }
+
+      if (!email) {
+        throw new Error("Email requis");
+      }
+
+      if (limit !== null && members.length >= limit) {
+        throw new Error("La limite de membres du plan est atteinte");
+      }
+
+      const resolvedTeamId = await ensureTeam();
+      const membership = await authService.inviteTeamMember(
+        resolvedTeamId,
+        email,
+        role,
+        name,
+      );
+
+      setMembers((prev) => {
+        const exists = prev.some((member) => member.$id === membership.$id);
+        if (exists) {
+          return prev;
+        }
+        return [...prev, membership];
+      });
+
+      return membership;
+    },
+    [ensureTeam, limit, members.length, organization],
+  );
+
+  const removeMember = useCallback(
+    async (membershipId: string) => {
+      if (!teamId) {
+        throw new Error("Aucune équipe associée");
+      }
+
+      await authService.removeTeamMember(teamId, membershipId);
+      setMembers((prev) => prev.filter((member) => member.$id !== membershipId));
+    },
+    [teamId],
+  );
+
+  return {
+    teamId,
+    members,
+    loading,
+    error,
+    limit,
+    isAtLimit,
+    inviteMember,
+    removeMember,
+    refresh: fetchMembers,
+  };
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,13 @@
-import { account, databases, databaseId, COLLECTIONS } from "./appwrite-config";
+import {
+  account,
+  databases,
+  databaseId,
+  COLLECTIONS,
+  teams,
+} from "./appwrite-config";
 import { ID, Query } from "appwrite";
+import type { Models } from "appwrite";
+import { getPlanLimit } from "./plans";
 
 export interface User {
   $id: string;
@@ -14,13 +22,24 @@ export interface Organization {
   $id: string;
   name: string;
   logo?: string;
+  description?: string;
   plan: "starter" | "pro" | "enterprise";
   ownerId: string;
   members: string[];
   createdAt: string;
+  teamId?: string;
 }
 
 export class AuthService {
+  private getInviteRedirectUrl() {
+    if (typeof window !== "undefined") {
+      return `${window.location.origin}/auth/callback`;
+    }
+
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+    return `${baseUrl.replace(/\/$/, "")}/auth/callback`;
+  }
+
   // Authentication
   async login(email: string, password: string) {
     try {
@@ -112,10 +131,15 @@ export class AuthService {
   }
 
   // Organization Management
-  async createOrganization(name: string, plan: "starter" | "pro" | "enterprise" = "starter") {
+  async createOrganization(
+    name: string,
+    plan: "starter" | "pro" | "enterprise" = "starter",
+  ) {
     try {
       const user = await this.getCurrentUser();
       if (!user) throw new Error("User not authenticated");
+
+      const team = await teams.create(ID.unique(), name, ["owner"]);
 
       const organization = await databases.createDocument(
         databaseId,
@@ -127,8 +151,32 @@ export class AuthService {
           ownerId: user.$id,
           members: [user.$id],
           createdAt: new Date().toISOString(),
+          teamId: team.$id,
         }
       );
+
+      try {
+        const membership = await teams.createMembership(
+          team.$id,
+          ["owner"],
+          user.email,
+          undefined,
+          undefined,
+          this.getInviteRedirectUrl(),
+          user.name,
+        );
+
+        if ((membership as any).secret) {
+          await teams.updateMembershipStatus(
+            team.$id,
+            membership.$id,
+            user.$id,
+            (membership as any).secret,
+          );
+        }
+      } catch (membershipError) {
+        console.warn("Unable to auto-accept owner membership:", membershipError);
+      }
 
       // Update user's organizations
       const userProfile = await this.getUserProfile(user.$id);
@@ -177,6 +225,115 @@ export class AuthService {
       );
     } catch (error) {
       throw error;
+    }
+  }
+
+  async ensureOrganizationTeam(
+    organizationId: string,
+    organizationName?: string,
+  ): Promise<string> {
+    const organization = (await this.getOrganization(organizationId)) as Organization;
+
+    if (organization.teamId) {
+      return organization.teamId;
+    }
+
+    const team = await teams.create(
+      ID.unique(),
+      organizationName || organization.name,
+      ["owner"],
+    );
+
+    const updated = await this.updateOrganization(organizationId, {
+      teamId: team.$id,
+    });
+
+    const currentUser = await this.getCurrentUser();
+    if (currentUser) {
+      try {
+        const membership = await teams.createMembership(
+          team.$id,
+          ["owner"],
+          currentUser.email,
+          undefined,
+          undefined,
+          this.getInviteRedirectUrl(),
+          currentUser.name,
+        );
+
+        if ((membership as any).secret) {
+          await teams.updateMembershipStatus(
+            team.$id,
+            membership.$id,
+            currentUser.$id,
+            (membership as any).secret,
+          );
+        }
+      } catch (membershipError) {
+        console.warn(
+          "Unable to auto-accept membership while ensuring organization team:",
+          membershipError,
+        );
+      }
+    }
+
+    return (updated as Organization).teamId || team.$id;
+  }
+
+  async listTeamMembers(teamId: string) {
+    return teams.listMemberships(teamId);
+  }
+
+  async inviteTeamMember(
+    teamId: string,
+    email: string,
+    role: string = "member",
+    name?: string,
+  ): Promise<Models.Membership> {
+    if (!email) {
+      throw new Error("Email requis pour inviter un membre");
+    }
+
+    const membership = await teams.createMembership(
+      teamId,
+      [role],
+      email,
+      undefined,
+      undefined,
+      this.getInviteRedirectUrl(),
+      name,
+    );
+
+    return membership;
+  }
+
+  async removeTeamMember(teamId: string, membershipId: string) {
+    return teams.deleteMembership(teamId, membershipId);
+  }
+
+  async syncOrganizationMembersFromTeam(
+    organizationId: string,
+    teamId: string,
+  ) {
+    try {
+      const { memberships } = await this.listTeamMembers(teamId);
+      const memberIds = memberships
+        .filter((membership) => membership.confirm)
+        .map((membership) => membership.userId)
+        .filter(Boolean);
+
+      const limit = getPlanLimit(
+        (await this.getOrganization(organizationId))?.plan || "starter",
+      );
+
+      await this.updateOrganization(organizationId, {
+        members: memberIds,
+      });
+
+      return { memberIds, limit };
+    } catch (error) {
+      console.warn("Unable to sync organization members:", error);
+      return null;
     }
   }
 

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -1,0 +1,35 @@
+export const PLAN_ORDER = ["starter", "pro", "enterprise"] as const;
+
+export type Plan = (typeof PLAN_ORDER)[number];
+
+export const PLAN_LIMITS: Record<Plan, number | null> = {
+  starter: 3,
+  pro: 10,
+  enterprise: null,
+};
+
+export const PLAN_LABELS: Record<Plan, string> = {
+  starter: "Starter",
+  pro: "Pro",
+  enterprise: "Enterprise",
+};
+
+export function getPlanLimit(plan: Plan): number | null {
+  return PLAN_LIMITS[plan];
+}
+
+export function isLimitReached(plan: Plan, memberCount: number) {
+  const limit = PLAN_LIMITS[plan];
+  if (limit === null) {
+    return false;
+  }
+  return memberCount >= limit;
+}
+
+export function getNextPlan(currentPlan: Plan): Plan | null {
+  const index = PLAN_ORDER.indexOf(currentPlan);
+  if (index === -1 || index === PLAN_ORDER.length - 1) {
+    return null;
+  }
+  return PLAN_ORDER[index + 1];
+}


### PR DESCRIPTION
## Summary
- ensure organizations are backed by Appwrite teams and expose helpers for listing, inviting, and removing members
- add a shared hook and plan metadata utilities for managing organization members and enforcing plan limits
- update team and organization settings pages to display real member data, send invites, and surface upgrade prompts

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fa4b3c6c83238da43f68aeee9ce5