### PR TITLE
Add content automation controls and processing stub

### DIFF
--- a/app/api/automation/process/route.ts
+++ b/app/api/automation/process/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { processScheduledContent } from "@/lib/automation-processor";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const result = await processScheduledContent();
+  const status = result.errors.length > 0 && result.processed === 0 ? 500 : 200;
+  return NextResponse.json(result, { status });
+}
+
+export async function GET() {
+  return POST();
+}

--- a/app/dashboard/content/articles/[type]/[projectId]/page.tsx
+++ b/app/dashboard/content/articles/[type]/[projectId]/page.tsx
@@ -21,10 +21,18 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
 import { databases } from "@/lib/appwrite-config";
 import { ID, Query } from "appwrite";
 import ContentGenerator from "@/components/dashboard/ContentGenerator";
-import { BookDashed, Briefcase, Copy, RefreshCcw, Trash2 } from "lucide-react";
+import ContentAutomationControls from "@/components/dashboard/ContentAutomationControls";
+import {
+  CHANNEL_LABELS,
+  formatScheduleDisplay,
+  getAutomationBadgeVariant,
+  getAutomationStatusLabel,
+} from "@/lib/content-automation";
+import { Briefcase, Copy, Trash2 } from "lucide-react";
 import { motion } from "framer-motion";
 
 export default function SocialContentPage() {
@@ -36,6 +44,17 @@ export default function SocialContentPage() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [contentToDelete, setContentToDelete] = useState<any>(null);
   const [confirmationText, setConfirmationText] = useState("");
+  const [selectedChannels, setSelectedChannels] = useState<string[]>([
+    "linkedin",
+  ]);
+  const [scheduledAt, setScheduledAt] = useState<string>("");
+  const [automationEnabled, setAutomationEnabled] = useState(false);
+
+  useEffect(() => {
+    if (selectedChannels.length === 0 && automationEnabled) {
+      setAutomationEnabled(false);
+    }
+  }, [selectedChannels, automationEnabled]);
 
   useEffect(() => {
     const fetchProject = async () => {
@@ -67,9 +86,25 @@ export default function SocialContentPage() {
     fetchContents();
   }, [projectId, currentOrganization, type]);
 
-  const handleSaveContent = async (content: string) => {
+  const handleSaveContent = async (
+    content: string,
+    generatedTopic: string,
+  ) => {
     if (!currentOrganization || !projectId || !user) return;
-    const topic = content.slice(0, 50);
+    const topic = generatedTopic?.trim() || content.slice(0, 50);
+    const scheduledIso = scheduledAt
+      ? new Date(scheduledAt).toISOString()
+      : null;
+    const automationActive = automationEnabled && selectedChannels.length > 0;
+    const now = new Date();
+    const scheduleDate = scheduledIso ? new Date(scheduledIso) : null;
+    const automationStatus = automationActive
+      ? scheduleDate
+        ? scheduleDate.getTime() > now.getTime()
+          ? "scheduled"
+          : "ready"
+        : "pending"
+      : "manual";
     const doc = await databases.createDocument(
       process.env.NEXT_PUBLIC_APPWRITE_DATABASE_ID!,
       process.env.NEXT_PUBLIC_APPWRITE_CONTENTS_COLLECTION_ID!,
@@ -82,6 +117,10 @@ export default function SocialContentPage() {
         topic,
         content,
         createdAt: new Date().toISOString(),
+        channels: selectedChannels,
+        scheduledAt: scheduledIso,
+        automationEnabled: automationActive,
+        automationStatus,
       },
     );
     setExistingContents((prev) => [doc, ...prev]);
@@ -155,6 +194,15 @@ Génère un contenu de type "${type}" en lien avec ce projet.`;
         </p>
       </motion.div>
 
+      <ContentAutomationControls
+        selectedChannels={selectedChannels}
+        onChannelsChange={setSelectedChannels}
+        scheduledAt={scheduledAt}
+        onScheduledAtChange={setScheduledAt}
+        automationEnabled={automationEnabled}
+        onAutomationChange={setAutomationEnabled}
+      />
+
       <ContentGenerator
         type={type as string}
         title={`Générateur de contenu ${type}`}
@@ -198,27 +246,55 @@ Génère un contenu de type "${type}" en lien avec ce projet.`;
                       {item.content}
                     </p>
                   </CardContent>
-                  <CardFooter className="flex flex-wrap gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handleCopy(item.content, item.$id)}
-                    >
-                      <Copy className="w-4 h-4 mr-1" />
-                      {copiedId === item.$id ? "Copié !" : "Copier"}
-                    </Button>
+                  <CardFooter className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex flex-col gap-2 w-full sm:w-auto">
+                      <div className="flex flex-wrap gap-2">
+                        {Array.isArray(item.channels) && item.channels.length > 0 ? (
+                          item.channels.map((channel: string) => (
+                            <Badge key={channel} variant="secondary" className="capitalize">
+                              {CHANNEL_LABELS[channel] ?? channel}
+                            </Badge>
+                          ))
+                        ) : (
+                          <Badge variant="outline">Canaux non définis</Badge>
+                        )}
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <Badge variant={getAutomationBadgeVariant(item.automationStatus)}>
+                          {getAutomationStatusLabel(item.automationStatus)}
+                        </Badge>
+                        {item.scheduledAt ? (
+                          <span>
+                            Planifié pour {formatScheduleDisplay(item.scheduledAt)}
+                          </span>
+                        ) : item.automationEnabled ? (
+                          <span>En attente de planification</span>
+                        ) : null}
+                      </div>
+                    </div>
 
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => {
-                        setContentToDelete(item);
-                        setShowDeleteModal(true);
-                      }}
-                    >
-                      <Trash2 className="w-4 h-4 mr-1" />
-                      Supprimer
-                    </Button>
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleCopy(item.content, item.$id)}
+                      >
+                        <Copy className="w-4 h-4 mr-1" />
+                        {copiedId === item.$id ? "Copié !" : "Copier"}
+                      </Button>
+
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => {
+                          setContentToDelete(item);
+                          setShowDeleteModal(true);
+                        }}
+                      >
+                        <Trash2 className="w-4 h-4 mr-1" />
+                        Supprimer
+                      </Button>
+                    </div>
                   </CardFooter>
                 </Card>
               </motion.div>

--- a/components/dashboard/ContentGenerator.tsx
+++ b/components/dashboard/ContentGenerator.tsx
@@ -9,7 +9,7 @@ interface ContentGeneratorProps {
   description?: string;
   placeholder?: string;
   llmApiUrl?: string;
-  onGenerated?: (content: string) => void;
+  onGenerated?: (content: string, topic: string) => void;
 }
 
 export default function ContentGenerator({
@@ -59,7 +59,7 @@ export default function ContentGenerator({
       }
 
       setContent(data.answer);
-      onGenerated?.(data.answer);
+      onGenerated?.(data.answer, topic);
     } catch (err: any) {
       console.error("Erreur lors de la génération:", err);
       setError(err.message || "Erreur inconnue lors de la génération");

--- a/lib/automation-processor.ts
+++ b/lib/automation-processor.ts
@@ -1,0 +1,79 @@
+import { databases } from "@/lib/appwrite-config";
+import { Query } from "appwrite";
+
+interface ProcessScheduledResult {
+  processed: number;
+  failed: number;
+  documentIds: string[];
+  errors: string[];
+}
+
+export async function processScheduledContent(): Promise<ProcessScheduledResult> {
+  const databaseId = process.env.NEXT_PUBLIC_APPWRITE_DATABASE_ID;
+  const collectionId = process.env.NEXT_PUBLIC_APPWRITE_CONTENTS_COLLECTION_ID;
+
+  if (!databaseId || !collectionId) {
+    return {
+      processed: 0,
+      failed: 0,
+      documentIds: [],
+      errors: [
+        "Configuration Appwrite manquante : vérifiez les variables d'environnement de base de données et de collection.",
+      ],
+    };
+  }
+
+  const nowIso = new Date().toISOString();
+  const processedIds: string[] = [];
+  const errors: string[] = [];
+  let failed = 0;
+
+  try {
+    const scheduled = await databases.listDocuments(databaseId, collectionId, [
+      Query.equal("automationEnabled", true),
+      Query.lessEqual("scheduledAt", nowIso),
+    ]);
+
+    for (const doc of scheduled.documents) {
+      try {
+        await databases.updateDocument(databaseId, collectionId, doc.$id, {
+          automationStatus: "processing",
+          automationLastRunAt: nowIso,
+        });
+
+        // Stubbed delivery : en environnement réel, appeler ici les APIs LinkedIn, Instagram, email.
+        await databases.updateDocument(databaseId, collectionId, doc.$id, {
+          automationStatus: "posted",
+          automationLastRunAt: nowIso,
+          automationResult:
+            "Publication simulée : le connecteur exécutera la diffusion lors de l'intégration.",
+        });
+
+        processedIds.push(doc.$id);
+      } catch (error: any) {
+        failed += 1;
+        const message =
+          error?.message ||
+          `Erreur inconnue lors du traitement du document ${doc.$id}`;
+        errors.push(message);
+        await databases.updateDocument(databaseId, collectionId, doc.$id, {
+          automationStatus: "failed",
+          automationLastRunAt: nowIso,
+          automationResult: message,
+        });
+      }
+    }
+  } catch (error: any) {
+    errors.push(
+      error?.message ||
+        "Impossible de récupérer les contenus planifiés pour l'automatisation.",
+    );
+  }
+
+  return {
+    processed: processedIds.length,
+    failed,
+    documentIds: processedIds,
+    errors,
+  };
+}

--- a/lib/content-automation.ts
+++ b/lib/content-automation.ts
@@ -1,0 +1,92 @@
+export const AUTOMATION_CHANNELS = [
+  { id: "linkedin", label: "LinkedIn" },
+  { id: "instagram", label: "Instagram" },
+  { id: "email", label: "Email" },
+] as const;
+
+export type AutomationChannel =
+  (typeof AUTOMATION_CHANNELS)[number]["id"];
+
+export type AutomationStatus =
+  | "manual"
+  | "pending"
+  | "scheduled"
+  | "ready"
+  | "processing"
+  | "posted"
+  | "failed";
+
+export const CHANNEL_LABELS: Record<string, string> =
+  AUTOMATION_CHANNELS.reduce(
+    (acc, channel) => {
+      acc[channel.id] = channel.label;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+
+export function formatScheduleDisplay(value?: string | null): string {
+  if (!value) {
+    return "Non planifié";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Planification inconnue";
+  }
+
+  return date.toLocaleString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function getAutomationStatusLabel(
+  status?: string | null,
+): string {
+  switch (status) {
+    case "pending":
+      return "Automatisation en attente";
+    case "scheduled":
+      return "Diffusion programmée";
+    case "ready":
+      return "Prêt pour diffusion";
+    case "processing":
+      return "Automatisation en cours";
+    case "posted":
+      return "Diffusion effectuée";
+    case "failed":
+      return "Erreur d'automatisation";
+    case "manual":
+    case undefined:
+    case null:
+      return "Publication manuelle";
+    default:
+      return status.toString();
+  }
+}
+
+export function getAutomationBadgeVariant(
+  status?: string | null,
+): "default" | "secondary" | "destructive" | "outline" {
+  switch (status) {
+    case "pending":
+      return "secondary";
+    case "scheduled":
+    case "ready":
+    case "processing":
+      return "default";
+    case "posted":
+      return "outline";
+    case "failed":
+      return "destructive";
+    case "manual":
+    case undefined:
+    case null:
+    default:
+      return "outline";
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable automation controls so content creators can pick channels, schedule distribution times, and toggle automation
- persist automation metadata on article, social, and visual content records while surfacing channel badges and automation status in the dashboards
- introduce a stubbed automation processor API/worker hook that marks due posts as processed for future integrations

## Testing
- pnpm lint *(fails: ESLint is not installed in the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fdfdf7d48323a53190082340d5ba