### PR TITLE
Add engagement analytics dashboard enhancements

### DIFF
--- a/app/api/recommendations/route.ts
+++ b/app/api/recommendations/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+
+interface RecommendationsPayload {
+  analyticsSummary: string;
+  planName: string;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { analyticsSummary, planName }: RecommendationsPayload =
+      await request.json();
+
+    if (!analyticsSummary) {
+      return NextResponse.json(
+        { error: "Les métriques d'engagement sont requises." },
+        { status: 400 },
+      );
+    }
+
+    const origin = request.nextUrl.origin;
+    const response = await fetch(`${origin}/api/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        topic: `Recommande des optimisations marketing pour ${planName} en te basant sur ces métriques: ${analyticsSummary}. Donne des actions concrètes, rapides à mettre en place et adaptées au plan.`,
+        tone: "professional",
+        logo: null,
+        primaryColor: "#2563EB",
+        secondaryColor: "#9333EA",
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch AI recommendations");
+    }
+
+    const data = await response.json();
+    const rawText: string = data?.linkedinPost ?? "";
+    const suggestions = rawText
+      .split(/\n+/)
+      .map((item: string) => item.trim().replace(/^[-•]/, "").trim())
+      .filter((item: string) => item.length > 0)
+      .slice(0, 6);
+
+    return NextResponse.json({
+      suggestions,
+      raw: data,
+    });
+  } catch (error) {
+    console.error("Error generating recommendations", error);
+    return NextResponse.json(
+      {
+        error:
+          "Impossible de générer des recommandations pour le moment. Veuillez réessayer plus tard.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,22 +1,8 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { AuthGuard } from "@/components/auth/AuthGuard";
-import {
-  SidebarInset,
-  SidebarProvider,
-  SidebarTrigger,
-} from "@/components/ui/sidebar";
-import { AppSidebar } from "@/components/app-sidebar";
-import { Separator } from "@/components/ui/separator";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
 import {
   Card,
   CardContent,
@@ -26,19 +12,161 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
-  Plus,
-  Sparkles,
-  TrendingUp,
-  Users,
-  FileText,
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Progress } from "@/components/ui/progress";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  AlertCircle,
+  ArrowUpRight,
+  BarChart2,
   Calendar,
+  FileText,
+  Loader2,
+  Sparkles,
+  TrendingDown,
+  TrendingUp,
 } from "lucide-react";
 import { CreateOrganizationDialog } from "@/components/dashboard/CreateOrganizationDialog";
 import AuthPage from "../auth/page";
 import { PRICING_PLANS_BY_ID, type PlanId } from "@/lib/plans";
+import {
+  fetchEngagementMetrics,
+  buildEngagementInsights,
+  buildAnalyticsSummaryPayload,
+  type EngagementInsights,
+} from "@/lib/analytics";
+
+const numberFormatter = new Intl.NumberFormat("fr-FR");
+
+const chartConfig = {
+  views: {
+    label: "Vues",
+    color: "#2563EB",
+  },
+  clicks: {
+    label: "Clics",
+    color: "#F97316",
+  },
+  reactions: {
+    label: "Réactions",
+    color: "#8B5CF6",
+  },
+};
+
+function formatSummaryValue(label: string, value: number) {
+  if (label === "Taux d'engagement") {
+    return `${value}%`;
+  }
+  return numberFormatter.format(value);
+}
+
+function formatChange(change: number) {
+  const rounded = Math.abs(change).toFixed(1);
+  return `${change >= 0 ? "+" : "-"}${rounded}%`;
+}
 
 export default function Dashboard() {
   const { user, currentOrganization } = useAuth();
+  const [insights, setInsights] = useState<EngagementInsights | null>(null);
+  const [loadingMetrics, setLoadingMetrics] = useState(false);
+  const [metricsError, setMetricsError] = useState<string | null>(null);
+  const [recommendations, setRecommendations] = useState<string[]>([]);
+  const [loadingRecommendations, setLoadingRecommendations] = useState(false);
+  const [recommendationError, setRecommendationError] = useState<string | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!currentOrganization) {
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingMetrics(true);
+    setMetricsError(null);
+
+    const plan = (currentOrganization.plan ?? "starter") as PlanId;
+
+    fetchEngagementMetrics(currentOrganization.$id)
+      .then((metrics) => {
+        if (cancelled) return;
+        setInsights(buildEngagementInsights(metrics, plan));
+      })
+      .catch((error: unknown) => {
+        console.error("Erreur lors du chargement des métriques", error);
+        if (cancelled) return;
+        setMetricsError(
+          "Impossible de charger les métriques d'engagement. Vérifiez la configuration Appwrite.",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoadingMetrics(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentOrganization]);
+
+  const planDetails = currentOrganization
+    ? PRICING_PLANS_BY_ID[(currentOrganization.plan ?? "starter") as PlanId]
+    : null;
+
+  const analyticsSummary = useMemo(() => {
+    if (!insights) return "";
+    return buildAnalyticsSummaryPayload(insights);
+  }, [insights]);
+
+  const handleGenerateRecommendations = async () => {
+    if (!currentOrganization || !planDetails || !analyticsSummary) {
+      return;
+    }
+
+    setLoadingRecommendations(true);
+    setRecommendationError(null);
+
+    try {
+      const response = await fetch("/api/recommendations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          analyticsSummary,
+          planName: planDetails.name,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Request failed");
+      }
+
+      const data = await response.json();
+      setRecommendations(data.suggestions ?? []);
+    } catch (error) {
+      console.error("Erreur lors de la génération des recommandations", error);
+      setRecommendationError(
+        "Impossible de générer des recommandations pour le moment.",
+      );
+    } finally {
+      setLoadingRecommendations(false);
+    }
+  };
 
   if (!currentOrganization) {
     return (
@@ -61,19 +189,33 @@ export default function Dashboard() {
     );
   }
 
-  const planDetails = PRICING_PLANS_BY_ID[currentOrganization.plan as PlanId];
+  const benchmark = insights?.planBenchmark;
+  const weeklyProgress = benchmark?.weeklyViewTarget
+    ? Math.min(
+        100,
+        Math.round(
+          (benchmark.currentWeeklyViews / benchmark.weeklyViewTarget) * 100,
+        ),
+      )
+    : 0;
+  const engagementProgress = benchmark?.engagementRateTarget
+    ? Math.min(
+        100,
+        Math.round(
+          (benchmark.currentEngagementRate / benchmark.engagementRateTarget) *
+            100,
+        ),
+      )
+    : 0;
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-      {/* Welcome Section */}
       <div className="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
         <h1 className="text-2xl font-bold mb-2">
           Bienvenue, {user?.name} ! 👋
         </h1>
         <p className="text-muted-foreground mb-4">
-          Vous êtes dans l'organisation{" "}
-          <strong>{currentOrganization.name}</strong>. Créez du contenu
-          exceptionnel avec l'IA.
+          Vous êtes dans l'organisation <strong>{currentOrganization.name}</strong>. Créez du contenu exceptionnel avec l'IA.
         </p>
         <Button asChild>
           <a href="/generate">
@@ -83,102 +225,279 @@ export default function Dashboard() {
         </Button>
       </div>
 
-      {/* Quick Actions */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Génération rapide
-            </CardTitle>
-            <Sparkles className="h-4 w-4 text-purple-600" />
-          </CardHeader>
-          <CardContent>
-            <Button className="w-full" size="sm" asChild>
-              <a href="/generate">
-                <Plus className="mr-2 h-4 w-4" />
-                Créer du contenu
-              </a>
-            </Button>
-          </CardContent>
-        </Card>
+      {metricsError && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Erreur de métriques</AlertTitle>
+          <AlertDescription>{metricsError}</AlertDescription>
+        </Alert>
+      )}
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Ce mois-ci</CardTitle>
-            <TrendingUp className="h-4 w-4 text-green-600" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">0</div>
-            <p className="text-xs text-muted-foreground">Contenus créés</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Projets actifs
-            </CardTitle>
-            <FileText className="h-4 w-4 text-blue-600" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">0</div>
-            <p className="text-xs text-muted-foreground">Projets en cours</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Plan actuel</CardTitle>
-            <Users className="h-4 w-4 text-orange-600" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold capitalize">
-              {planDetails?.name ?? currentOrganization.plan}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {planDetails?.price ?? "Tarif personnalisé"}
-            </p>
-          </CardContent>
-        </Card>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {(insights?.summaryCards || []).map((card) => {
+          const positive = card.change >= 0;
+          return (
+            <Card key={card.label}>
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <div>
+                  <CardTitle className="text-sm font-medium">
+                    {card.label}
+                  </CardTitle>
+                  <CardDescription>{card.helper}</CardDescription>
+                </div>
+                <span
+                  className={`rounded-full px-2 py-1 text-xs font-medium ${positive ? "bg-emerald-100 text-emerald-700" : "bg-rose-100 text-rose-700"}`}
+                >
+                  {formatChange(card.change)}
+                </span>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-2">
+                  <div className="text-2xl font-bold">
+                    {formatSummaryValue(card.label, card.value)}
+                  </div>
+                  {positive ? (
+                    <TrendingUp className="h-5 w-5 text-emerald-500" />
+                  ) : (
+                    <TrendingDown className="h-5 w-5 text-rose-500" />
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
       </div>
 
-      {/* Recent Activity */}
-      <div className="grid gap-4 md:grid-cols-2">
-        <Card>
+      <div className="grid gap-4 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
           <CardHeader>
-            <CardTitle>Contenu récent</CardTitle>
-            <CardDescription>Vos dernières créations</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="text-center py-8 text-muted-foreground">
-              <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
-              <p>Aucun contenu créé pour le moment</p>
-              <Button variant="outline" className="mt-4" asChild>
-                <a href="/generate">Créer votre premier contenu</a>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Projets</CardTitle>
+            <CardTitle>Performance d'engagement</CardTitle>
             <CardDescription>
-              Organisez votre contenu par projet
+              Suivez l'évolution des vues, clics et réactions sur vos contenus.
             </CardDescription>
           </CardHeader>
-          <CardContent>
-            <div className="text-center py-8 text-muted-foreground">
-              <Calendar className="h-12 w-12 mx-auto mb-4 opacity-50" />
-              <p>Aucun projet créé pour le moment</p>
-              <Button variant="outline" className="mt-4">
-                <Plus className="mr-2 h-4 w-4" />
-                Créer un projet
-              </Button>
+          <CardContent className="h-[320px]">
+            {loadingMetrics ? (
+              <div className="h-full flex items-center justify-center text-muted-foreground">
+                <Loader2 className="h-6 w-6 animate-spin mr-2" />
+                Chargement des métriques...
+              </div>
+            ) : insights?.timeseries?.length ? (
+              <ChartContainer config={chartConfig} className="h-full">
+                <AreaChart data={insights.timeseries}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                  <XAxis dataKey="date" tickLine={false} axisLine={false} />
+                  <YAxis tickLine={false} axisLine={false} />
+                  <ChartTooltip content={<ChartTooltipContent />} />
+                  <Area
+                    type="monotone"
+                    dataKey="views"
+                    stroke="var(--color-views)"
+                    fill="var(--color-views)"
+                    fillOpacity={0.15}
+                    name="Vues"
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="clicks"
+                    stroke="var(--color-clicks)"
+                    fill="var(--color-clicks)"
+                    fillOpacity={0.15}
+                    name="Clics"
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="reactions"
+                    stroke="var(--color-reactions)"
+                    fill="var(--color-reactions)"
+                    fillOpacity={0.15}
+                    name="Réactions"
+                  />
+                </AreaChart>
+              </ChartContainer>
+            ) : (
+              <div className="h-full flex flex-col items-center justify-center text-muted-foreground text-center">
+                <BarChart2 className="h-10 w-10 mb-3" />
+                <p>Aucune donnée d'engagement disponible pour le moment.</p>
+                <p className="text-sm">
+                  Publiez du contenu pour commencer à suivre vos performances.
+                </p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Objectifs du plan {planDetails?.name}</CardTitle>
+            <CardDescription>
+              Comparez vos performances hebdomadaires aux repères du plan.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div>
+              <div className="flex items-center justify-between text-sm font-medium">
+                <span>Vues hebdomadaires</span>
+                <span>
+                  {benchmark ? numberFormatter.format(benchmark.currentWeeklyViews) : 0}
+                  <span className="text-muted-foreground">
+                    {" "}/ {numberFormatter.format(benchmark?.weeklyViewTarget ?? 0)}
+                  </span>
+                </span>
+              </div>
+              <Progress value={weeklyProgress} className="mt-2" />
             </div>
+            <div>
+              <div className="flex items-center justify-between text-sm font-medium">
+                <span>Taux d'engagement</span>
+                <span>
+                  {benchmark ? `${benchmark.currentEngagementRate}%` : "0%"}
+                  <span className="text-muted-foreground">
+                    {" "}/ {benchmark ? `${benchmark.engagementRateTarget}%` : "0%"}
+                  </span>
+                </span>
+              </div>
+              <Progress value={engagementProgress} className="mt-2" />
+            </div>
+            {planDetails?.price && (
+              <div className="rounded-md bg-muted p-3 text-sm text-muted-foreground">
+                <p>
+                  {planDetails.name} · {planDetails.price}
+                </p>
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Top contenus</CardTitle>
+          <CardDescription>
+            Classement des contenus les plus performants sur la période suivie.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loadingMetrics ? (
+            <div className="flex items-center justify-center py-12 text-muted-foreground">
+              <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              Chargement des données…
+            </div>
+          ) : insights?.topContent?.length ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Contenu</TableHead>
+                  <TableHead className="text-right">Vues</TableHead>
+                  <TableHead className="text-right">Clics</TableHead>
+                  <TableHead className="text-right">Réactions</TableHead>
+                  <TableHead className="text-right">Taux d'engagement</TableHead>
+                  <TableHead className="text-right">Évolution S-1</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {insights.topContent.map((item) => (
+                  <TableRow key={item.contentId}>
+                    <TableCell className="font-medium">
+                      <div className="flex items-center gap-2">
+                        <FileText className="h-4 w-4 text-muted-foreground" />
+                        {item.title || item.contentId}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {numberFormatter.format(item.views)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {numberFormatter.format(item.clicks)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {numberFormatter.format(item.reactions)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {item.engagementRate}%
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {item.weekOverWeekChange >= 0 ? "+" : ""}
+                      {item.weekOverWeekChange}%
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <div className="text-center py-12 text-muted-foreground">
+              <Calendar className="h-8 w-8 mx-auto mb-3 opacity-60" />
+              <p>Aucun contenu n'a encore généré d'engagement mesurable.</p>
+              <p className="text-sm">
+                Lancez une campagne depuis l'onglet Génération pour alimenter ce tableau.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Recommandations IA</CardTitle>
+            <CardDescription>
+              Suggestions d'optimisation basées sur vos métriques récentes et votre plan.
+            </CardDescription>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleGenerateRecommendations}
+            disabled={loadingRecommendations || !insights?.metrics?.length}
+          >
+            {loadingRecommendations ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Génération…
+              </>
+            ) : (
+              <>
+                <ArrowUpRight className="mr-2 h-4 w-4" />
+                Générer
+              </>
+            )}
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {!insights?.metrics?.length ? (
+            <p className="text-sm text-muted-foreground">
+              Publiez du contenu et revenez pour obtenir des recommandations personnalisées.
+            </p>
+          ) : loadingRecommendations ? (
+            <div className="flex items-center justify-center py-6 text-muted-foreground">
+              <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              Analyse des métriques…
+            </div>
+          ) : recommendationError ? (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Recommandations indisponibles</AlertTitle>
+              <AlertDescription>{recommendationError}</AlertDescription>
+            </Alert>
+          ) : recommendations.length ? (
+            <ul className="space-y-3 text-sm">
+              {recommendations.map((suggestion, index) => (
+                <li
+                  key={`${suggestion}-${index}`}
+                  className="flex items-start gap-2 rounded-md border border-dashed border-muted-foreground/40 bg-muted/40 p-3"
+                >
+                  <Sparkles className="mt-0.5 h-4 w-4 text-primary" />
+                  <span>{suggestion}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              Cliquez sur « Générer » pour obtenir des pistes d'amélioration ciblées.
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,324 @@
+import { databases, databaseId, COLLECTIONS } from "@/lib/appwrite-config";
+import { Query, type Models } from "appwrite";
+
+export interface EngagementMetric extends Models.Document {
+  contentId: string;
+  organizationId: string;
+  views: number;
+  clicks: number;
+  reactions: number;
+  periodStart: string;
+  periodEnd?: string;
+  source?: string;
+}
+
+export interface EngagementTimeseriePoint {
+  date: string;
+  views: number;
+  clicks: number;
+  reactions: number;
+}
+
+export interface ContentPerformance {
+  contentId: string;
+  title?: string;
+  views: number;
+  clicks: number;
+  reactions: number;
+  engagementRate: number;
+  weekOverWeekChange: number;
+}
+
+export interface EngagementSummaryCard {
+  label: string;
+  value: number;
+  change: number;
+  helper: string;
+}
+
+export interface EngagementInsights {
+  metrics: EngagementMetric[];
+  timeseries: EngagementTimeseriePoint[];
+  summaryCards: EngagementSummaryCard[];
+  topContent: ContentPerformance[];
+  lastUpdated?: string;
+  planBenchmark: {
+    weeklyViewTarget: number;
+    engagementRateTarget: number;
+    currentWeeklyViews: number;
+    currentEngagementRate: number;
+  };
+}
+
+const BENCHMARKS: Record<
+  "starter" | "pro" | "enterprise",
+  { weeklyViewTarget: number; engagementRateTarget: number }
+> = {
+  starter: { weeklyViewTarget: 500, engagementRateTarget: 2.5 },
+  pro: { weeklyViewTarget: 2500, engagementRateTarget: 4 },
+  enterprise: { weeklyViewTarget: 6000, engagementRateTarget: 5 },
+};
+
+const round = (value: number, decimals = 1) => {
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
+};
+
+function percentChange(current: number, previous: number) {
+  if (previous === 0) {
+    return current === 0 ? 0 : 100;
+  }
+
+  return ((current - previous) / previous) * 100;
+}
+
+function calculateWeeklyWindow(metrics: EngagementMetric[], weeksAgo: number) {
+  const now = new Date();
+  const end = new Date(now);
+  end.setUTCDate(end.getUTCDate() - weeksAgo * 7);
+
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 7);
+
+  return metrics.filter((metric) => {
+    const period = new Date(metric.periodStart);
+    return period >= start && period < end;
+  });
+}
+
+function aggregatePeriod(metrics: EngagementMetric[]) {
+  return metrics.reduce(
+    (acc, metric) => {
+      acc.views += metric.views || 0;
+      acc.clicks += metric.clicks || 0;
+      acc.reactions += metric.reactions || 0;
+      return acc;
+    },
+    { views: 0, clicks: 0, reactions: 0 },
+  );
+}
+
+function buildTimeseries(metrics: EngagementMetric[]): EngagementTimeseriePoint[] {
+  const byDate = new Map<string, EngagementTimeseriePoint>();
+
+  metrics.forEach((metric) => {
+    const day = new Date(metric.periodStart).toISOString().slice(0, 10);
+    const existing = byDate.get(day) ?? {
+      date: day,
+      views: 0,
+      clicks: 0,
+      reactions: 0,
+    };
+
+    existing.views += metric.views || 0;
+    existing.clicks += metric.clicks || 0;
+    existing.reactions += metric.reactions || 0;
+
+    byDate.set(day, existing);
+  });
+
+  return Array.from(byDate.values()).sort((a, b) => a.date.localeCompare(b.date));
+}
+
+function buildTopContent(metrics: EngagementMetric[]): ContentPerformance[] {
+  const byContent = new Map<string, ContentPerformance>();
+
+  metrics.forEach((metric) => {
+    const existing = byContent.get(metric.contentId) ?? {
+      contentId: metric.contentId,
+      views: 0,
+      clicks: 0,
+      reactions: 0,
+      engagementRate: 0,
+      weekOverWeekChange: 0,
+    };
+
+    existing.views += metric.views || 0;
+    existing.clicks += metric.clicks || 0;
+    existing.reactions += metric.reactions || 0;
+
+    const totalInteractions = existing.clicks + existing.reactions;
+    existing.engagementRate = existing.views
+      ? (totalInteractions / existing.views) * 100
+      : 0;
+
+    byContent.set(metric.contentId, existing);
+  });
+
+  const lastWeek = calculateWeeklyWindow(metrics, 0);
+  const previousWeek = calculateWeeklyWindow(metrics, 1);
+
+  const previousByContent = new Map<string, number>();
+  previousWeek.forEach((metric) => {
+    previousByContent.set(
+      metric.contentId,
+      (previousByContent.get(metric.contentId) || 0) + metric.views,
+    );
+  });
+
+  const currentByContent = new Map<string, number>();
+  lastWeek.forEach((metric) => {
+    currentByContent.set(
+      metric.contentId,
+      (currentByContent.get(metric.contentId) || 0) + metric.views,
+    );
+  });
+
+  byContent.forEach((value, key) => {
+    const currentViews = currentByContent.get(key) || 0;
+    const prevViews = previousByContent.get(key) || 0;
+    value.weekOverWeekChange = percentChange(currentViews, prevViews);
+  });
+
+  return Array.from(byContent.values())
+    .sort((a, b) => b.views - a.views)
+    .slice(0, 5)
+    .map((item) => ({
+      ...item,
+      engagementRate: round(item.engagementRate),
+      weekOverWeekChange: round(item.weekOverWeekChange ?? 0),
+    }));
+}
+
+function buildSummaryCards(
+  current: { views: number; clicks: number; reactions: number },
+  previous: { views: number; clicks: number; reactions: number },
+) {
+  const currentEngagement = current.views
+    ? ((current.clicks + current.reactions) / current.views) * 100
+    : 0;
+  const previousEngagement = previous.views
+    ? ((previous.clicks + previous.reactions) / previous.views) * 100
+    : 0;
+
+  return [
+    {
+      label: "Vues",
+      value: current.views,
+      change: percentChange(current.views, previous.views),
+      helper: "vs. semaine précédente",
+    },
+    {
+      label: "Clics",
+      value: current.clicks,
+      change: percentChange(current.clicks, previous.clicks),
+      helper: "vs. semaine précédente",
+    },
+    {
+      label: "Réactions",
+      value: current.reactions,
+      change: percentChange(current.reactions, previous.reactions),
+      helper: "vs. semaine précédente",
+    },
+    {
+      label: "Taux d'engagement",
+      value: currentEngagement,
+      change: percentChange(currentEngagement, previousEngagement),
+      helper: "(clics + réactions) / vues",
+    },
+  ];
+}
+
+export async function fetchEngagementMetrics(
+  organizationId: string,
+  limit = 120,
+) {
+  if (!COLLECTIONS.ENGAGEMENT) {
+    throw new Error(
+      "La collection d'engagement Appwrite n'est pas configurée (ENGAGEMENT).",
+    );
+  }
+
+  const response = await databases.listDocuments<EngagementMetric>(
+    databaseId,
+    COLLECTIONS.ENGAGEMENT,
+    [
+      Query.equal("organizationId", organizationId),
+      Query.orderDesc("periodStart"),
+      Query.limit(limit),
+    ],
+  );
+
+  return response.documents;
+}
+
+export function buildEngagementInsights(
+  metrics: EngagementMetric[],
+  plan: "starter" | "pro" | "enterprise",
+): EngagementInsights {
+  if (!metrics.length) {
+    return {
+      metrics,
+      timeseries: [],
+      summaryCards: buildSummaryCards(
+        { views: 0, clicks: 0, reactions: 0 },
+        { views: 0, clicks: 0, reactions: 0 },
+      ),
+      topContent: [],
+      lastUpdated: undefined,
+      planBenchmark: {
+        weeklyViewTarget: BENCHMARKS[plan].weeklyViewTarget,
+        engagementRateTarget: BENCHMARKS[plan].engagementRateTarget,
+        currentWeeklyViews: 0,
+        currentEngagementRate: 0,
+      },
+    };
+  }
+
+  const lastWeekMetrics = calculateWeeklyWindow(metrics, 0);
+  const previousWeekMetrics = calculateWeeklyWindow(metrics, 1);
+
+  const currentTotals = aggregatePeriod(lastWeekMetrics);
+  const previousTotals = aggregatePeriod(previousWeekMetrics);
+
+  const timeseries = buildTimeseries(metrics);
+  const summaryCards = buildSummaryCards(currentTotals, previousTotals).map(
+    (card) => ({
+      ...card,
+      value:
+        card.label === "Taux d'engagement"
+          ? round(card.value)
+          : Math.round(card.value),
+      change: round(card.change),
+    }),
+  );
+
+  const totalInteractions = currentTotals.clicks + currentTotals.reactions;
+  const currentEngagementRate = currentTotals.views
+    ? (totalInteractions / currentTotals.views) * 100
+    : 0;
+
+  const benchmark = BENCHMARKS[plan];
+
+  return {
+    metrics,
+    timeseries,
+    summaryCards,
+    topContent: buildTopContent(metrics),
+    lastUpdated: metrics[0]?.periodEnd || metrics[0]?.periodStart,
+    planBenchmark: {
+      weeklyViewTarget: benchmark.weeklyViewTarget,
+      engagementRateTarget: benchmark.engagementRateTarget,
+      currentWeeklyViews: Math.round(currentTotals.views),
+      currentEngagementRate: round(currentEngagementRate),
+    },
+  };
+}
+
+export function buildAnalyticsSummaryPayload(insights: EngagementInsights) {
+  const cardSummaries = insights.summaryCards
+    .map(
+      (card) =>
+        `${card.label}: ${card.value} (${card.change >= 0 ? "+" : ""}${round(card.change)}% ${card.helper})`,
+    )
+    .join("; ");
+
+  const topContentSummary = insights.topContent
+    .map(
+      (item) =>
+        `Contenu ${item.contentId}: ${item.views} vues, ${item.engagementRate}% d'engagement (${item.weekOverWeekChange >= 0 ? "+" : ""}${item.weekOverWeekChange}% vs. S-1)`,
+    )
+    .join("; ");
+
+  return [cardSummaries, topContentSummary].filter(Boolean).join(" | ");
+}

--- a/lib/appwrite-config.ts
+++ b/lib/appwrite-config.ts
@@ -11,6 +11,8 @@ export const COLLECTIONS = {
   PROJECTS: process.env.NEXT_PUBLIC_APPWRITE_PROJECTS_COLLECTION_ID ?? "",
   CONTENT: process.env.NEXT_PUBLIC_APPWRITE_CONTENT_COLLECTION_ID ?? "",
   USERS: process.env.NEXT_PUBLIC_APPWRITE_USERS_COLLECTION_ID ?? "",
+  ENGAGEMENT:
+    process.env.NEXT_PUBLIC_APPWRITE_ENGAGEMENT_COLLECTION_ID ?? "",
 };
 console.log(endpoint);
 console.log(projectId);


### PR DESCRIPTION
## Summary
- track Appwrite engagement metrics and expose analytics helpers for aggregation
- replace dashboard widgets with metric-driven charts, tables, and plan benchmark progress
- add an AI recommendations API and surface suggestions in the dashboard

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fe00c4cc8323befc62b98a6ec54b