### PR TITLE
Fix missing scheduling state in social content page

### DIFF
--- a/app/dashboard/content/social/[type]/[projectId]/page.tsx
+++ b/app/dashboard/content/social/[type]/[projectId]/page.tsx
@@ -21,6 +21,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { databases } from "@/lib/appwrite-config";
 import { ID, Query } from "appwrite";
@@ -34,7 +35,6 @@ import {
 } from "@/lib/content-automation";
 import { Briefcase, Copy, Trash2 } from "lucide-react";
 import { motion } from "framer-motion";
-import { cn } from "@/lib/utils";
 
 export default function SocialContentPage() {
   const { currentOrganization, user } = useAuth();
@@ -50,6 +50,10 @@ export default function SocialContentPage() {
   ]);
   const [scheduledAt, setScheduledAt] = useState<string>("");
   const [automationEnabled, setAutomationEnabled] = useState(false);
+  const [scheduleDialogOpen, setScheduleDialogOpen] = useState(false);
+  const [contentToSchedule, setContentToSchedule] = useState<any>(null);
+  const [scheduleDate, setScheduleDate] = useState("");
+  const [updatingContentId, setUpdatingContentId] = useState<string | null>(null);
 
   useEffect(() => {
     if (selectedChannels.length === 0 && automationEnabled) {


### PR DESCRIPTION
## Summary
- add missing state hooks required by the scheduling dialog on the social content page
- import the Label component used inside the scheduling dialog to prevent runtime errors
- remove an unused `cn` import

## Testing
- `npm run lint` *(fails: ESLint is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70b9db46083239935d160bb1da7b6