### PR TITLE
Add dashboard management tool pages

### DIFF
--- a/app/dashboard/tools/ai-models/page.tsx
+++ b/app/dashboard/tools/ai-models/page.tsx
@@ -1,0 +1,547 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Cpu, Activity, Workflow, RefreshCw, Trash2, Plus } from "lucide-react";
+
+import { AuthGuard } from "@/components/auth/AuthGuard";
+import { DashboardEditableListSection } from "@/components/dashboard/DashboardEditableListSection";
+import { DashboardStatCard } from "@/components/dashboard/DashboardStatCard";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/contexts/AuthContext";
+import AuthPage from "@/app/auth/page";
+import type { AIModelConfig } from "@/lib/auth";
+
+const PROVIDER_OPTIONS = ["OpenAI", "Anthropic", "Mistral", "Cohere", "Custom"] as const;
+const STATUS_OPTIONS: { value: AIModelConfig["status"]; label: string }[] = [
+  { value: "active", label: "Actif" },
+  { value: "paused", label: "En pause" },
+];
+
+const STATUS_DESCRIPTIONS: Record<AIModelConfig["status"], string> = {
+  active: "Modèles prêts à générer du contenu.",
+  paused: "Configurations désactivées ou en attente.",
+};
+
+const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+});
+
+interface NewModelForm {
+  name: string;
+  provider: (typeof PROVIDER_OPTIONS)[number];
+  useCase: string;
+  status: AIModelConfig["status"];
+  temperature: number;
+  maxTokens: number;
+  instructions: string;
+  lastTrainedAt: string;
+}
+
+export default function AIModelsPage() {
+  const { currentOrganization, updateCurrentOrganization } = useAuth();
+  const { toast } = useToast();
+  const [models, setModels] = useState<AIModelConfig[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [newModel, setNewModel] = useState<NewModelForm>({
+    name: "",
+    provider: "OpenAI",
+    useCase: "",
+    status: "active",
+    temperature: 0.7,
+    maxTokens: 800,
+    instructions: "",
+    lastTrainedAt: "",
+  });
+
+  useEffect(() => {
+    if (currentOrganization?.aiModelConfigs?.length) {
+      setModels(currentOrganization.aiModelConfigs);
+    } else {
+      setModels([]);
+    }
+  }, [currentOrganization?.aiModelConfigs]);
+
+  const activeCount = useMemo(
+    () => models.filter((model) => model.status === "active").length,
+    [models],
+  );
+
+  const uniqueUseCases = useMemo(() => {
+    return Array.from(new Set(models.map((model) => model.useCase).filter(Boolean))).slice(0, 4);
+  }, [models]);
+
+  const lastSync = useMemo(() => {
+    if (!models.length) return null;
+    return models
+      .slice()
+      .sort((a, b) =>
+        new Date(b.lastTrainedAt ?? 0).getTime() - new Date(a.lastTrainedAt ?? 0).getTime(),
+      )[0];
+  }, [models]);
+
+  const providers = useMemo(() => {
+    return Array.from(new Set(models.map((model) => model.provider))).slice(0, 6);
+  }, [models]);
+
+  const addModel = () => {
+    if (!newModel.name.trim()) {
+      toast({
+        title: "Nom requis",
+        description: "Ajoutez un nom pour créer une configuration.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!newModel.useCase.trim()) {
+      toast({
+        title: "Cas d'usage requis",
+        description: "Précisez l'objectif principal du modèle.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const id =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `${Date.now()}`;
+
+    const model: AIModelConfig = {
+      id,
+      name: newModel.name.trim(),
+      provider: newModel.provider,
+      useCase: newModel.useCase.trim(),
+      status: newModel.status,
+      temperature: Number.isFinite(newModel.temperature) ? newModel.temperature : undefined,
+      maxTokens: Number.isFinite(newModel.maxTokens) ? newModel.maxTokens : undefined,
+      instructions: newModel.instructions.trim() || undefined,
+      lastTrainedAt: newModel.lastTrainedAt || new Date().toISOString(),
+    };
+
+    setModels((prev) => [model, ...prev]);
+    setNewModel({
+      name: "",
+      provider: newModel.provider,
+      useCase: "",
+      status: "active",
+      temperature: 0.7,
+      maxTokens: 800,
+      instructions: "",
+      lastTrainedAt: "",
+    });
+
+    toast({
+      title: "Modèle ajouté",
+      description: "Configuration IA prête à être utilisée.",
+    });
+  };
+
+  const updateModel = <K extends keyof AIModelConfig>(
+    modelId: string,
+    field: K,
+    value: AIModelConfig[K],
+  ) => {
+    setModels((prev) =>
+      prev.map((model) => (model.id === modelId ? { ...model, [field]: value } : model)),
+    );
+  };
+
+  const removeModel = (modelId: string) => {
+    setModels((prev) => prev.filter((model) => model.id !== modelId));
+  };
+
+  const handleSave = async () => {
+    if (!currentOrganization) return;
+
+    setSaving(true);
+    try {
+      await updateCurrentOrganization({ aiModelConfigs: models });
+      toast({
+        title: "Modèles sauvegardés",
+        description: "Vos configurations IA ont été mises à jour.",
+      });
+    } catch (error) {
+      console.error("Erreur lors de la sauvegarde des modèles", error);
+      toast({
+        title: "Erreur",
+        description: "Impossible d'enregistrer les modèles pour le moment.",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!currentOrganization) {
+    return (
+      <AuthGuard fallback={<AuthPage />}>
+        <div className="min-h-screen flex items-center justify-center p-4">
+          <Card className="w-full max-w-md">
+            <CardHeader className="text-center">
+              <CardTitle>Modèles IA</CardTitle>
+              <CardDescription>
+                Sélectionnez une organisation pour gérer vos configurations IA.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Modèles IA</h1>
+          <p className="text-sm text-muted-foreground">
+            Centralisez les paramètres d'inférence et assurez un suivi de vos prompts.
+          </p>
+        </div>
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? "Enregistrement..." : "Enregistrer"}
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <DashboardStatCard
+          title="Total modèles"
+          value={models.length}
+          subtitle={models.length ? "Configurations disponibles" : "Ajoutez votre premier modèle"}
+          icon={Cpu}
+        />
+        <DashboardStatCard
+          title="Actifs"
+          value={activeCount}
+          subtitle="Prêts à générer"
+          icon={Activity}
+        />
+        <DashboardStatCard
+          title="Cas d'usage"
+          value={uniqueUseCases.length}
+          subtitle="Diversité des workflows"
+          icon={Workflow}
+        >
+          {uniqueUseCases.length ? (
+            <div className="flex flex-wrap gap-2 pt-2">
+              {uniqueUseCases.map((useCase) => (
+                <Badge key={useCase} variant="secondary">
+                  {useCase}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </DashboardStatCard>
+        <DashboardStatCard
+          title="Dernière synchro"
+          value={lastSync?.lastTrainedAt ? dateFormatter.format(new Date(lastSync.lastTrainedAt)) : "-"}
+          subtitle={lastSync ? lastSync.name : "Aucun entraînement enregistré"}
+          icon={RefreshCw}
+        >
+          {providers.length ? (
+            <div className="flex flex-wrap gap-2 pt-2">
+              {providers.map((provider) => (
+                <Badge key={provider} variant="secondary">
+                  {provider}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </DashboardStatCard>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Ajouter un modèle</CardTitle>
+          <CardDescription>
+            Définissez les paramètres d'appel et les instructions d'orchestration.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="model-name">Nom</Label>
+              <Input
+                id="model-name"
+                value={newModel.name}
+                placeholder="Ex : Rédaction LinkedIn Senior"
+                onChange={(event) => setNewModel((prev) => ({ ...prev, name: event.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Fournisseur</Label>
+              <Select
+                value={newModel.provider}
+                onValueChange={(value: (typeof PROVIDER_OPTIONS)[number]) =>
+                  setNewModel((prev) => ({ ...prev, provider: value }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PROVIDER_OPTIONS.map((provider) => (
+                    <SelectItem key={provider} value={provider}>
+                      {provider}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Cas d'usage</Label>
+            <Input
+              value={newModel.useCase}
+              placeholder="Brief social media, Email nurturing, FAQ..."
+              onChange={(event) => setNewModel((prev) => ({ ...prev, useCase: event.target.value }))}
+            />
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <Label>Statut</Label>
+              <Select
+                value={newModel.status}
+                onValueChange={(value: AIModelConfig["status"]) =>
+                  setNewModel((prev) => ({ ...prev, status: value }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {STATUS_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Température</Label>
+              <Input
+                type="number"
+                step="0.1"
+                min="0"
+                max="1"
+                value={newModel.temperature}
+                onChange={(event) =>
+                  setNewModel((prev) => ({
+                    ...prev,
+                    temperature: Number(event.target.value),
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Tokens max</Label>
+              <Input
+                type="number"
+                min="1"
+                value={newModel.maxTokens}
+                onChange={(event) =>
+                  setNewModel((prev) => ({
+                    ...prev,
+                    maxTokens: Number(event.target.value),
+                  }))
+                }
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Instructions système</Label>
+            <Textarea
+              value={newModel.instructions}
+              rows={4}
+              placeholder="Ton, structure, contraintes, variables dynamiques"
+              onChange={(event) => setNewModel((prev) => ({ ...prev, instructions: event.target.value }))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Dernière synchronisation</Label>
+            <Input
+              type="date"
+              value={newModel.lastTrainedAt}
+              onChange={(event) => setNewModel((prev) => ({ ...prev, lastTrainedAt: event.target.value }))}
+            />
+          </div>
+          <Button onClick={addModel} className="w-full sm:w-auto">
+            <Plus className="mr-2 h-4 w-4" /> Ajouter le modèle
+          </Button>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        {STATUS_OPTIONS.map((statusOption) => {
+          const items = models.filter((model) => model.status === statusOption.value);
+          return (
+            <DashboardEditableListSection
+              key={statusOption.value}
+              title={statusOption.label}
+              description={STATUS_DESCRIPTIONS[statusOption.value]}
+              items={items}
+              getItemKey={(model) => model.id}
+              itemClassName="space-y-3"
+              emptyState={
+                <p className="text-sm text-muted-foreground">
+                  Aucun modèle dans cet état pour le moment.
+                </p>
+              }
+              renderItem={(model) => (
+                <div className="space-y-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <Input
+                      value={model.name}
+                      onChange={(event) => updateModel(model.id, "name", event.target.value)}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="text-muted-foreground hover:text-destructive"
+                      onClick={() => removeModel(model.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">Fournisseur</Label>
+                      <Select
+                        value={model.provider}
+                        onValueChange={(value: (typeof PROVIDER_OPTIONS)[number]) =>
+                          updateModel(model.id, "provider", value)
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {PROVIDER_OPTIONS.map((provider) => (
+                            <SelectItem key={provider} value={provider}>
+                              {provider}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">Cas d'usage</Label>
+                      <Input
+                        value={model.useCase}
+                        onChange={(event) => updateModel(model.id, "useCase", event.target.value)}
+                      />
+                    </div>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">Statut</Label>
+                      <Select
+                        value={model.status}
+                        onValueChange={(value: AIModelConfig["status"]) =>
+                          updateModel(model.id, "status", value)
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {STATUS_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">Température</Label>
+                      <Input
+                        type="number"
+                        step="0.1"
+                        min="0"
+                        max="1"
+                        value={model.temperature ?? 0}
+                        onChange={(event) =>
+                          updateModel(
+                            model.id,
+                            "temperature",
+                            Number.isNaN(Number(event.target.value))
+                              ? undefined
+                              : Number(event.target.value),
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">Tokens max</Label>
+                      <Input
+                        type="number"
+                        min="1"
+                        value={model.maxTokens ?? 0}
+                        onChange={(event) =>
+                          updateModel(
+                            model.id,
+                            "maxTokens",
+                            Number.isNaN(Number(event.target.value))
+                              ? undefined
+                              : Number(event.target.value),
+                          )
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Instructions</Label>
+                    <Textarea
+                      value={model.instructions ?? ""}
+                      rows={4}
+                      placeholder="Prompt système, style attendu, variables"
+                      onChange={(event) => updateModel(model.id, "instructions", event.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs text-muted-foreground">Dernière synchro</Label>
+                    <Input
+                      type="date"
+                      value={model.lastTrainedAt ? model.lastTrainedAt.slice(0, 10) : ""}
+                      onChange={(event) =>
+                        updateModel(
+                          model.id,
+                          "lastTrainedAt",
+                          event.target.value ? new Date(event.target.value).toISOString() : undefined,
+                        )
+                      }
+                    />
+                  </div>
+                </div>
+              )}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/tools/audiences/page.tsx
+++ b/app/dashboard/tools/audiences/page.tsx
@@ -1,0 +1,497 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Users, Target, BarChart3, MessageCircle, Trash2, Plus } from "lucide-react";
+
+import { AuthGuard } from "@/components/auth/AuthGuard";
+import { DashboardEditableListSection } from "@/components/dashboard/DashboardEditableListSection";
+import { DashboardStatCard } from "@/components/dashboard/DashboardStatCard";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/contexts/AuthContext";
+import AuthPage from "@/app/auth/page";
+import type { AudiencePersona } from "@/lib/auth";
+
+const STAGE_OPTIONS: { value: NonNullable<AudiencePersona["stage"]>; label: string }[] = [
+  { value: "awareness", label: "Découverte" },
+  { value: "consideration", label: "Évaluation" },
+  { value: "decision", label: "Décision" },
+  { value: "retention", label: "Fidélisation" },
+];
+
+const STAGE_DESCRIPTIONS: Record<NonNullable<AudiencePersona["stage"]>, string> = {
+  awareness: "Personas qui découvrent votre offre.",
+  consideration: "Comparaison active de solutions.",
+  decision: "Prêts à s'engager, requièrent la preuve finale.",
+  retention: "Clients existants à fidéliser ou upseller.",
+};
+
+function parseList(value: string) {
+  return value
+    .split(/\n|,/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+interface NewPersonaForm {
+  name: string;
+  segment: string;
+  stage: NonNullable<AudiencePersona["stage"]>;
+  description: string;
+  pains: string;
+  goals: string;
+  channels: string;
+  notes: string;
+}
+
+export default function AudiencePersonasPage() {
+  const { currentOrganization, updateCurrentOrganization } = useAuth();
+  const { toast } = useToast();
+  const [personas, setPersonas] = useState<AudiencePersona[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [newPersona, setNewPersona] = useState<NewPersonaForm>({
+    name: "",
+    segment: "",
+    stage: "awareness",
+    description: "",
+    pains: "",
+    goals: "",
+    channels: "",
+    notes: "",
+  });
+
+  useEffect(() => {
+    if (currentOrganization?.audiencePersonas?.length) {
+      setPersonas(currentOrganization.audiencePersonas);
+    } else {
+      setPersonas([]);
+    }
+  }, [currentOrganization?.audiencePersonas]);
+
+  const stageCounts = useMemo(() => {
+    return STAGE_OPTIONS.reduce<Record<NonNullable<AudiencePersona["stage"]>, number>>((acc, option) => {
+      acc[option.value] = personas.filter((persona) => persona.stage === option.value).length;
+      return acc;
+    }, {
+      awareness: 0,
+      consideration: 0,
+      decision: 0,
+      retention: 0,
+    });
+  }, [personas]);
+
+  const strategicSegments = useMemo(() => {
+    return Array.from(new Set(personas.map((persona) => persona.segment).filter(Boolean))).slice(0, 4);
+  }, [personas]);
+
+  const primaryChannels = useMemo(() => {
+    return Array.from(
+      new Set(
+        personas
+          .flatMap((persona) => persona.preferredChannels ?? [])
+          .map((channel) => channel.trim())
+          .filter(Boolean),
+      ),
+    ).slice(0, 6);
+  }, [personas]);
+
+  const addPersona = () => {
+    if (!newPersona.name.trim()) {
+      toast({
+        title: "Nom requis",
+        description: "Ajoutez un nom pour créer un persona.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const id =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `${Date.now()}`;
+
+    const persona: AudiencePersona = {
+      id,
+      name: newPersona.name.trim(),
+      segment: newPersona.segment.trim() || undefined,
+      stage: newPersona.stage,
+      description: newPersona.description.trim() || undefined,
+      pains: parseList(newPersona.pains),
+      goals: parseList(newPersona.goals),
+      preferredChannels: parseList(newPersona.channels),
+      notes: newPersona.notes.trim() || undefined,
+    };
+
+    setPersonas((prev) => [persona, ...prev]);
+    setNewPersona({
+      name: "",
+      segment: "",
+      stage: "awareness",
+      description: "",
+      pains: "",
+      goals: "",
+      channels: "",
+      notes: "",
+    });
+
+    toast({
+      title: "Persona ajouté",
+      description: "La segmentation a été enrichie.",
+    });
+  };
+
+  const updatePersona = <K extends keyof AudiencePersona>(
+    personaId: string,
+    field: K,
+    value: AudiencePersona[K],
+  ) => {
+    setPersonas((prev) =>
+      prev.map((persona) => (persona.id === personaId ? { ...persona, [field]: value } : persona)),
+    );
+  };
+
+  const removePersona = (personaId: string) => {
+    setPersonas((prev) => prev.filter((persona) => persona.id !== personaId));
+  };
+
+  const handleSave = async () => {
+    if (!currentOrganization) return;
+
+    setSaving(true);
+    try {
+      await updateCurrentOrganization({ audiencePersonas: personas });
+      toast({
+        title: "Personas sauvegardés",
+        description: "Vos profils cibles ont été mis à jour.",
+      });
+    } catch (error) {
+      console.error("Erreur lors de la sauvegarde des personas", error);
+      toast({
+        title: "Erreur",
+        description: "Impossible d'enregistrer les personas pour le moment.",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!currentOrganization) {
+    return (
+      <AuthGuard fallback={<AuthPage />}>
+        <div className="min-h-screen flex items-center justify-center p-4">
+          <Card className="w-full max-w-md">
+            <CardHeader className="text-center">
+              <CardTitle>Personas cibles</CardTitle>
+              <CardDescription>
+                Sélectionnez une organisation pour accéder aux personas marketing.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Personas cibles</h1>
+          <p className="text-sm text-muted-foreground">
+            Documentez les besoins, freins et canaux prioritaires de vos audiences.
+          </p>
+        </div>
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? "Enregistrement..." : "Enregistrer"}
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <DashboardStatCard
+          title="Total personas"
+          value={personas.length}
+          subtitle={personas.length ? "Profils disponibles" : "Ajoutez votre premier persona"}
+          icon={Users}
+        />
+        <DashboardStatCard
+          title="Stade dominant"
+          value={(() => {
+            const sortedStages = [...STAGE_OPTIONS].sort(
+              (a, b) => (stageCounts[b.value] ?? 0) - (stageCounts[a.value] ?? 0),
+            );
+            const topStage = sortedStages[0];
+            return topStage ? topStage.label : "-";
+          })()}
+          subtitle="Distribution entonnoir"
+          icon={BarChart3}
+        />
+        <DashboardStatCard
+          title="Segments clés"
+          value={strategicSegments.length}
+          subtitle="Segments activés"
+          icon={Target}
+        >
+          {strategicSegments.length ? (
+            <div className="flex flex-wrap gap-2 pt-2">
+              {strategicSegments.map((segment) => (
+                <Badge key={segment} variant="secondary">
+                  {segment}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </DashboardStatCard>
+        <DashboardStatCard title="Canaux prioritaires" icon={MessageCircle}>
+          {primaryChannels.length ? (
+            <div className="flex flex-wrap gap-2">
+              {primaryChannels.map((channel) => (
+                <Badge key={channel} variant="secondary">
+                  {channel}
+                </Badge>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Aucun canal renseigné pour le moment.
+            </p>
+          )}
+        </DashboardStatCard>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Ajouter un persona</CardTitle>
+          <CardDescription>
+            Capturez les informations indispensables pour personnaliser vos campagnes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="persona-name">Nom</Label>
+              <Input
+                id="persona-name"
+                value={newPersona.name}
+                placeholder="Ex : Marie, Directrice Marketing"
+                onChange={(event) => setNewPersona((prev) => ({ ...prev, name: event.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="persona-segment">Segment / Industrie</Label>
+              <Input
+                id="persona-segment"
+                value={newPersona.segment}
+                placeholder="SaaS B2B, Retail, Scale-up..."
+                onChange={(event) => setNewPersona((prev) => ({ ...prev, segment: event.target.value }))}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Stade dans le parcours</Label>
+            <Select
+              value={newPersona.stage}
+              onValueChange={(value: NonNullable<AudiencePersona["stage"]>) =>
+                setNewPersona((prev) => ({ ...prev, stage: value }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STAGE_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Résumé</Label>
+            <Textarea
+              value={newPersona.description}
+              rows={3}
+              placeholder="Contexte, responsabilités, objectifs prioritaires"
+              onChange={(event) => setNewPersona((prev) => ({ ...prev, description: event.target.value }))}
+            />
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Freins / douleurs</Label>
+              <Textarea
+                value={newPersona.pains}
+                rows={3}
+                placeholder="Séparez par ligne"
+                onChange={(event) => setNewPersona((prev) => ({ ...prev, pains: event.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Objectifs</Label>
+              <Textarea
+                value={newPersona.goals}
+                rows={3}
+                placeholder="Séparez par ligne"
+                onChange={(event) => setNewPersona((prev) => ({ ...prev, goals: event.target.value }))}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Canaux privilégiés</Label>
+            <Textarea
+              value={newPersona.channels}
+              rows={3}
+              placeholder="LinkedIn, Événements, Podcast..."
+              onChange={(event) => setNewPersona((prev) => ({ ...prev, channels: event.target.value }))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Notes</Label>
+            <Textarea
+              value={newPersona.notes}
+              rows={3}
+              placeholder="Triggers, contenus favoris, call-to-action efficaces"
+              onChange={(event) => setNewPersona((prev) => ({ ...prev, notes: event.target.value }))}
+            />
+          </div>
+          <Button onClick={addPersona} className="w-full sm:w-auto">
+            <Plus className="mr-2 h-4 w-4" /> Ajouter le persona
+          </Button>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-4">
+        {STAGE_OPTIONS.map((stage) => {
+          const items = personas.filter((persona) => persona.stage === stage.value);
+          return (
+            <DashboardEditableListSection
+              key={stage.value}
+              title={stage.label}
+              description={STAGE_DESCRIPTIONS[stage.value]}
+              items={items}
+              getItemKey={(persona) => persona.id}
+              itemClassName="space-y-3"
+              emptyState={
+                <p className="text-sm text-muted-foreground">
+                  Aucun persona dans ce stade pour le moment.
+                </p>
+              }
+              renderItem={(persona) => (
+                <div className="space-y-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <Input
+                      value={persona.name}
+                      onChange={(event) => updatePersona(persona.id, "name", event.target.value)}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="text-muted-foreground hover:text-destructive"
+                      onClick={() => removePersona(persona.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">Segment</Label>
+                      <Input
+                        value={persona.segment ?? ""}
+                        onChange={(event) => updatePersona(persona.id, "segment", event.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">Stade</Label>
+                      <Select
+                        value={persona.stage ?? "awareness"}
+                        onValueChange={(value: NonNullable<AudiencePersona["stage"]>) =>
+                          updatePersona(persona.id, "stage", value)
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {STAGE_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Résumé</Label>
+                    <Textarea
+                      value={persona.description ?? ""}
+                      rows={3}
+                      placeholder="Situation, enjeux, besoins"
+                      onChange={(event) => updatePersona(persona.id, "description", event.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Freins / douleurs</Label>
+                    <Textarea
+                      value={(persona.pains ?? []).join("\n")}
+                      rows={3}
+                      placeholder="Listez un point par ligne"
+                      onChange={(event) => updatePersona(persona.id, "pains", parseList(event.target.value))}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Objectifs</Label>
+                    <Textarea
+                      value={(persona.goals ?? []).join("\n")}
+                      rows={3}
+                      placeholder="Listez un objectif par ligne"
+                      onChange={(event) => updatePersona(persona.id, "goals", parseList(event.target.value))}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Canaux préférés</Label>
+                    <Textarea
+                      value={(persona.preferredChannels ?? []).join("\n")}
+                      rows={3}
+                      placeholder="LinkedIn, Email, Podcast..."
+                      onChange={(event) =>
+                        updatePersona(persona.id, "preferredChannels", parseList(event.target.value))
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Notes</Label>
+                    <Textarea
+                      value={persona.notes ?? ""}
+                      rows={3}
+                      placeholder="Astuce conversion, objections, partenariats"
+                      onChange={(event) => updatePersona(persona.id, "notes", event.target.value)}
+                    />
+                  </div>
+                </div>
+              )}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/tools/brand/page.tsx
+++ b/app/dashboard/tools/brand/page.tsx
@@ -1,0 +1,471 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Palette, Sparkles, PenSquare, FolderCog, Trash2, Plus } from "lucide-react";
+
+import { AuthGuard } from "@/components/auth/AuthGuard";
+import { DashboardEditableListSection } from "@/components/dashboard/DashboardEditableListSection";
+import { DashboardStatCard } from "@/components/dashboard/DashboardStatCard";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/contexts/AuthContext";
+import AuthPage from "@/app/auth/page";
+import type { BrandGuideline, BrandGuidelineCategory } from "@/lib/auth";
+
+const CATEGORY_OPTIONS: { value: BrandGuidelineCategory; label: string }[] = [
+  { value: "voice", label: "Voix & ton" },
+  { value: "visual", label: "Identité visuelle" },
+  { value: "messaging", label: "Messages clés" },
+  { value: "campaign", label: "Campagnes" },
+  { value: "compliance", label: "Conformité" },
+  { value: "other", label: "Autres" },
+];
+
+const CATEGORY_DESCRIPTIONS: Record<BrandGuidelineCategory, string> = {
+  voice: "Définissez le ton, le vocabulaire et la posture de marque.",
+  visual: "Précisez les usages couleurs, logos et compositions.",
+  messaging: "Clarifiez les piliers et arguments clés.",
+  campaign: "Documentez les déclinaisons par campagne ou lancement.",
+  compliance: "Mentionnez obligations légales ou mentions obligatoires.",
+  other: "Capturez tout autre élément utile au marketing.",
+};
+
+const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+});
+
+interface NewGuidelineForm {
+  title: string;
+  category: BrandGuidelineCategory;
+  description: string;
+  owner: string;
+  toneKeywords: string;
+  assets: string;
+}
+
+function parseList(value: string) {
+  return value
+    .split(/\n|,/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export default function BrandGuidelinesPage() {
+  const { currentOrganization, updateCurrentOrganization } = useAuth();
+  const { toast } = useToast();
+  const [guidelines, setGuidelines] = useState<BrandGuideline[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [newGuideline, setNewGuideline] = useState<NewGuidelineForm>({
+    title: "",
+    category: "voice",
+    description: "",
+    owner: "",
+    toneKeywords: "",
+    assets: "",
+  });
+
+  useEffect(() => {
+    if (currentOrganization?.brandGuidelines?.length) {
+      setGuidelines(currentOrganization.brandGuidelines);
+    } else {
+      setGuidelines([]);
+    }
+  }, [currentOrganization?.brandGuidelines]);
+
+  const categoryCounts = useMemo(() => {
+    return CATEGORY_OPTIONS.reduce<Record<BrandGuidelineCategory, number>>((acc, option) => {
+      acc[option.value] = guidelines.filter((item) => item.category === option.value).length;
+      return acc;
+    }, {
+      voice: 0,
+      visual: 0,
+      messaging: 0,
+      campaign: 0,
+      compliance: 0,
+      other: 0,
+    });
+  }, [guidelines]);
+
+  const lastUpdated = useMemo(() => {
+    if (!guidelines.length) return null;
+    return guidelines
+      .slice()
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
+  }, [guidelines]);
+
+  const toneKeywords = useMemo(() => {
+    const keywords = guidelines.flatMap((item) => item.toneKeywords ?? []);
+    return Array.from(new Set(keywords)).slice(0, 6);
+  }, [guidelines]);
+
+  const assetCount = useMemo(() => {
+    return guidelines.reduce((total, item) => total + (item.assets?.length ?? 0), 0);
+  }, [guidelines]);
+
+  const addGuideline = () => {
+    if (!newGuideline.title.trim()) {
+      toast({
+        title: "Titre requis",
+        description: "Ajoutez un titre pour créer une directive.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const id =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `${Date.now()}`;
+
+    const guideline: BrandGuideline = {
+      id,
+      title: newGuideline.title.trim(),
+      category: newGuideline.category,
+      description: newGuideline.description.trim(),
+      owner: newGuideline.owner.trim() || undefined,
+      toneKeywords: parseList(newGuideline.toneKeywords),
+      assets: parseList(newGuideline.assets),
+      updatedAt: new Date().toISOString(),
+    };
+
+    setGuidelines((prev) => [guideline, ...prev]);
+    setNewGuideline({
+      title: "",
+      category: newGuideline.category,
+      description: "",
+      owner: "",
+      toneKeywords: "",
+      assets: "",
+    });
+
+    toast({
+      title: "Directive ajoutée",
+      description: "Votre charte a été enrichie.",
+    });
+  };
+
+  const updateGuideline = <K extends keyof BrandGuideline>(
+    guidelineId: string,
+    field: K,
+    value: BrandGuideline[K],
+  ) => {
+    setGuidelines((prev) =>
+      prev.map((item) =>
+        item.id === guidelineId
+          ? {
+              ...item,
+              [field]: value,
+              updatedAt: new Date().toISOString(),
+            }
+          : item,
+      ),
+    );
+  };
+
+  const removeGuideline = (guidelineId: string) => {
+    setGuidelines((prev) => prev.filter((item) => item.id !== guidelineId));
+  };
+
+  const handleSave = async () => {
+    if (!currentOrganization) return;
+
+    setSaving(true);
+    try {
+      await updateCurrentOrganization({ brandGuidelines: guidelines });
+      toast({
+        title: "Charte sauvegardée",
+        description: "Vos directives de marque ont été mises à jour.",
+      });
+    } catch (error) {
+      console.error("Erreur lors de la sauvegarde des directives", error);
+      toast({
+        title: "Erreur",
+        description: "Impossible d'enregistrer la charte pour le moment.",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!currentOrganization) {
+    return (
+      <AuthGuard fallback={<AuthPage />}>
+        <div className="min-h-screen flex items-center justify-center p-4">
+          <Card className="w-full max-w-md">
+            <CardHeader className="text-center">
+              <CardTitle>Charte de marque</CardTitle>
+              <CardDescription>
+                Sélectionnez une organisation pour accéder aux directives de marque.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Charte de marque</h1>
+          <p className="text-sm text-muted-foreground">
+            Harmonisez vos contenus avec une base documentaire claire et actionnable.
+          </p>
+        </div>
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? "Enregistrement..." : "Enregistrer"}
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <DashboardStatCard
+          title="Total directives"
+          value={guidelines.length}
+          subtitle={guidelines.length ? "Éléments prêts à l'usage" : "Ajoutez votre première directive"}
+          icon={Palette}
+        />
+        <DashboardStatCard
+          title="Voix de marque"
+          value={categoryCounts.voice}
+          subtitle="Garde-fous rédactionnels"
+          icon={Sparkles}
+        />
+        <DashboardStatCard
+          title="Identité visuelle"
+          value={categoryCounts.visual}
+          subtitle="Logos, palettes, compositions"
+          icon={PenSquare}
+        />
+        <DashboardStatCard
+          title="Dernière mise à jour"
+          value={lastUpdated ? dateFormatter.format(new Date(lastUpdated.updatedAt)) : "-"}
+          subtitle={lastUpdated ? lastUpdated.title : "Aucune directive pour le moment"}
+          icon={FolderCog}
+        >
+          {toneKeywords.length ? (
+            <div className="flex flex-wrap gap-2 pt-2">
+              {toneKeywords.map((keyword) => (
+                <Badge key={keyword} variant="secondary">
+                  {keyword}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+          {assetCount ? (
+            <p className="text-xs text-muted-foreground pt-2">
+              {assetCount} ressource{assetCount > 1 ? "s" : ""} référencée{assetCount > 1 ? "s" : ""}.
+            </p>
+          ) : null}
+        </DashboardStatCard>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Ajouter une directive</CardTitle>
+          <CardDescription>
+            Décrivez les éléments essentiels pour guider vos équipes créatives.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="guideline-title">Titre</Label>
+              <Input
+                id="guideline-title"
+                value={newGuideline.title}
+                placeholder="Ex : Ton LinkedIn, Palette de couleurs"
+                onChange={(event) => setNewGuideline((prev) => ({ ...prev, title: event.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Catégorie</Label>
+              <Select
+                value={newGuideline.category}
+                onValueChange={(value: BrandGuidelineCategory) =>
+                  setNewGuideline((prev) => ({ ...prev, category: value }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CATEGORY_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Description</Label>
+            <Textarea
+              value={newGuideline.description}
+              rows={4}
+              placeholder="Décrivez les règles, exclusions et exemples concrets"
+              onChange={(event) => setNewGuideline((prev) => ({ ...prev, description: event.target.value }))}
+            />
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Référent</Label>
+              <Input
+                value={newGuideline.owner}
+                placeholder="Nom du responsable"
+                onChange={(event) => setNewGuideline((prev) => ({ ...prev, owner: event.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Mots-clés de ton</Label>
+              <Textarea
+                value={newGuideline.toneKeywords}
+                rows={3}
+                placeholder="Séparez par virgule ou retour à la ligne"
+                onChange={(event) =>
+                  setNewGuideline((prev) => ({ ...prev, toneKeywords: event.target.value }))
+                }
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Ressources / assets</Label>
+            <Textarea
+              value={newGuideline.assets}
+              rows={3}
+              placeholder="Liens Figma, dossiers Drive, templates..."
+              onChange={(event) => setNewGuideline((prev) => ({ ...prev, assets: event.target.value }))}
+            />
+          </div>
+          <Button onClick={addGuideline} className="w-full sm:w-auto">
+            <Plus className="mr-2 h-4 w-4" /> Ajouter à la charte
+          </Button>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-3">
+        {CATEGORY_OPTIONS.map((category) => {
+          const items = guidelines.filter((item) => item.category === category.value);
+          return (
+            <DashboardEditableListSection
+              key={category.value}
+              title={category.label}
+              description={CATEGORY_DESCRIPTIONS[category.value]}
+              items={items}
+              getItemKey={(item) => item.id}
+              itemClassName="space-y-3"
+              emptyState={
+                <p className="text-sm text-muted-foreground">
+                  Aucune directive enregistrée pour cette catégorie.
+                </p>
+              }
+              renderItem={(item) => (
+                <div className="space-y-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <Input
+                      value={item.title}
+                      onChange={(event) => updateGuideline(item.id, "title", event.target.value)}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="text-muted-foreground hover:text-destructive"
+                      onClick={() => removeGuideline(item.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Description</Label>
+                    <Textarea
+                      value={item.description}
+                      rows={4}
+                      placeholder="Règles, nuances, exemples"
+                      onChange={(event) => updateGuideline(item.id, "description", event.target.value)}
+                    />
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">Référent</Label>
+                      <Input
+                        value={item.owner ?? ""}
+                        onChange={(event) => updateGuideline(item.id, "owner", event.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">Catégorie</Label>
+                      <Select
+                        value={item.category}
+                        onValueChange={(value: BrandGuidelineCategory) =>
+                          updateGuideline(item.id, "category", value)
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {CATEGORY_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Mots-clés</Label>
+                    <Textarea
+                      value={(item.toneKeywords ?? []).join("\n")}
+                      rows={3}
+                      placeholder="Séparez par ligne"
+                      onChange={(event) =>
+                        updateGuideline(item.id, "toneKeywords", parseList(event.target.value))
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Ressources</Label>
+                    <Textarea
+                      value={(item.assets ?? []).join("\n")}
+                      rows={3}
+                      placeholder="Liens et documents utiles"
+                      onChange={(event) =>
+                        updateGuideline(item.id, "assets", parseList(event.target.value))
+                      }
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Dernière mise à jour : {dateFormatter.format(new Date(item.updatedAt))}
+                  </p>
+                </div>
+              )}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/tools/calendar/page.tsx
+++ b/app/dashboard/tools/calendar/page.tsx
@@ -1,0 +1,514 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  CalendarDays,
+  CheckCircle,
+  Clock3,
+  Megaphone,
+  Trash2,
+  Plus,
+} from "lucide-react";
+
+import { AuthGuard } from "@/components/auth/AuthGuard";
+import { DashboardEditableListSection } from "@/components/dashboard/DashboardEditableListSection";
+import { DashboardStatCard } from "@/components/dashboard/DashboardStatCard";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/contexts/AuthContext";
+import AuthPage from "@/app/auth/page";
+import type { EditorialCalendarEntry, EditorialCalendarStatus } from "@/lib/auth";
+
+const STATUS_OPTIONS: { value: EditorialCalendarStatus; label: string }[] = [
+  { value: "draft", label: "À planifier" },
+  { value: "in-production", label: "En production" },
+  { value: "scheduled", label: "Programmés" },
+  { value: "published", label: "Publiés" },
+];
+
+const STATUS_DESCRIPTIONS: Record<EditorialCalendarStatus, string> = {
+  draft: "Briefs à enrichir ou dates à fixer.",
+  "in-production": "Contenus en cours de création.",
+  scheduled: "Contenus prêts et planifiés.",
+  published: "Contenus déjà diffusés.",
+};
+
+const CONTENT_TYPES = [
+  "Post social",
+  "Newsletter",
+  "Article de blog",
+  "Vidéo",
+  "Webinaire",
+  "Podcast",
+];
+
+const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+});
+
+interface NewEntryForm {
+  title: string;
+  channel: string;
+  contentType: string;
+  publishDate: string;
+  owner: string;
+  status: EditorialCalendarStatus;
+  objective: string;
+  notes: string;
+}
+
+export default function EditorialCalendarPage() {
+  const { currentOrganization, updateCurrentOrganization } = useAuth();
+  const { toast } = useToast();
+  const [entries, setEntries] = useState<EditorialCalendarEntry[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [newEntry, setNewEntry] = useState<NewEntryForm>({
+    title: "",
+    channel: "",
+    contentType: CONTENT_TYPES[0],
+    publishDate: "",
+    owner: "",
+    status: "draft",
+    objective: "",
+    notes: "",
+  });
+
+  useEffect(() => {
+    if (currentOrganization?.editorialCalendar?.length) {
+      setEntries(currentOrganization.editorialCalendar);
+    } else {
+      setEntries([]);
+    }
+  }, [currentOrganization?.editorialCalendar]);
+
+  const statusCounts = useMemo(() => {
+    return STATUS_OPTIONS.reduce<Record<EditorialCalendarStatus, number>>((acc, option) => {
+      acc[option.value] = entries.filter((entry) => entry.status === option.value).length;
+      return acc;
+    }, {
+      draft: 0,
+      "in-production": 0,
+      scheduled: 0,
+      published: 0,
+    });
+  }, [entries]);
+
+  const activeChannels = useMemo(() => {
+    return Array.from(
+      new Set(entries.map((entry) => entry.channel.trim()).filter((channel) => channel)),
+    ).slice(0, 6);
+  }, [entries]);
+
+  const nextScheduled = useMemo(() => {
+    const futureEntries = entries
+      .filter((entry) => entry.publishDate && new Date(entry.publishDate) >= new Date())
+      .sort((a, b) => new Date(a.publishDate).getTime() - new Date(b.publishDate).getTime());
+    return futureEntries[0];
+  }, [entries]);
+
+  const publishedThisMonth = useMemo(() => {
+    const now = new Date();
+    return entries.filter((entry) => {
+      if (!entry.publishDate) return false;
+      const date = new Date(entry.publishDate);
+      return (
+        entry.status === "published" &&
+        date.getMonth() === now.getMonth() &&
+        date.getFullYear() === now.getFullYear()
+      );
+    }).length;
+  }, [entries]);
+
+  const addEntry = () => {
+    if (!newEntry.title.trim()) {
+      toast({
+        title: "Titre requis",
+        description: "Ajoutez un titre pour planifier le contenu.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!newEntry.publishDate) {
+      toast({
+        title: "Date de publication requise",
+        description: "Sélectionnez une date pour ce contenu.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const id =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `${Date.now()}`;
+
+    const entry: EditorialCalendarEntry = {
+      id,
+      title: newEntry.title.trim(),
+      channel: newEntry.channel.trim() || "À définir",
+      contentType: newEntry.contentType,
+      owner: newEntry.owner.trim() || undefined,
+      status: newEntry.status,
+      publishDate: newEntry.publishDate,
+      objective: newEntry.objective.trim() || undefined,
+      notes: newEntry.notes.trim() || undefined,
+      assets: [],
+    };
+
+    setEntries((prev) => [entry, ...prev]);
+    setNewEntry({
+      title: "",
+      channel: "",
+      contentType: CONTENT_TYPES[0],
+      publishDate: "",
+      owner: "",
+      status: "draft",
+      objective: "",
+      notes: "",
+    });
+
+    toast({
+      title: "Contenu ajouté",
+      description: "Le planning éditorial a été mis à jour.",
+    });
+  };
+
+  const updateEntry = <K extends keyof EditorialCalendarEntry>(
+    entryId: string,
+    field: K,
+    value: EditorialCalendarEntry[K],
+  ) => {
+    setEntries((prev) =>
+      prev.map((entry) => (entry.id === entryId ? { ...entry, [field]: value } : entry)),
+    );
+  };
+
+  const removeEntry = (entryId: string) => {
+    setEntries((prev) => prev.filter((entry) => entry.id !== entryId));
+  };
+
+  const handleSave = async () => {
+    if (!currentOrganization) return;
+
+    setSaving(true);
+    try {
+      await updateCurrentOrganization({ editorialCalendar: entries });
+      toast({
+        title: "Planning sauvegardé",
+        description: "Toutes les modifications ont été enregistrées.",
+      });
+    } catch (error) {
+      console.error("Erreur lors de la mise à jour du planning", error);
+      toast({
+        title: "Erreur",
+        description: "Impossible d'enregistrer le planning pour le moment.",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!currentOrganization) {
+    return (
+      <AuthGuard fallback={<AuthPage />}>
+        <div className="min-h-screen flex items-center justify-center p-4">
+          <Card className="w-full max-w-md">
+            <CardHeader className="text-center">
+              <CardTitle>Planning éditorial</CardTitle>
+              <CardDescription>
+                Sélectionnez une organisation pour gérer votre calendrier de contenus.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold">Planning éditorial</h1>
+          <p className="text-sm text-muted-foreground">
+            Pilotez vos publications à venir et assurez une présence régulière.
+          </p>
+        </div>
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? "Enregistrement..." : "Enregistrer"}
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <DashboardStatCard
+          title="Total planifié"
+          value={entries.length}
+          subtitle={entries.length ? "Contenus suivis" : "Ajoutez votre premier contenu"}
+          icon={CalendarDays}
+        />
+        <DashboardStatCard
+          title="Programmés"
+          value={statusCounts["scheduled"] ?? 0}
+          subtitle="Prêts à être publiés"
+          icon={Clock3}
+        />
+        <DashboardStatCard
+          title="Publiés ce mois"
+          value={publishedThisMonth}
+          subtitle="Suivi de la performance"
+          icon={CheckCircle}
+        />
+        <DashboardStatCard
+          title="Prochain contenu"
+          value={nextScheduled ? dateFormatter.format(new Date(nextScheduled.publishDate)) : "-"}
+          subtitle={nextScheduled ? nextScheduled.title : "Aucune publication planifiée"}
+          icon={Megaphone}
+        >
+          {activeChannels.length ? (
+            <div className="flex flex-wrap gap-2 pt-2">
+              {activeChannels.map((channel) => (
+                <Badge key={channel} variant="secondary">
+                  {channel}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </DashboardStatCard>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Ajouter un contenu</CardTitle>
+          <CardDescription>
+            Centralisez les informations nécessaires pour briefer vos équipes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="calendar-title">Titre</Label>
+              <Input
+                id="calendar-title"
+                value={newEntry.title}
+                placeholder="Ex : Lancement produit - vidéo YouTube"
+                onChange={(event) => setNewEntry((prev) => ({ ...prev, title: event.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="calendar-channel">Canal principal</Label>
+              <Input
+                id="calendar-channel"
+                value={newEntry.channel}
+                placeholder="LinkedIn, Blog, Email..."
+                onChange={(event) => setNewEntry((prev) => ({ ...prev, channel: event.target.value }))}
+              />
+            </div>
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <Label>Type de contenu</Label>
+              <Select
+                value={newEntry.contentType}
+                onValueChange={(value) => setNewEntry((prev) => ({ ...prev, contentType: value }))}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CONTENT_TYPES.map((type) => (
+                    <SelectItem key={type} value={type}>
+                      {type}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Date de publication</Label>
+              <Input
+                type="date"
+                value={newEntry.publishDate}
+                onChange={(event) =>
+                  setNewEntry((prev) => ({ ...prev, publishDate: event.target.value }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Responsable</Label>
+              <Input
+                value={newEntry.owner}
+                placeholder="Nom du référent"
+                onChange={(event) => setNewEntry((prev) => ({ ...prev, owner: event.target.value }))}
+              />
+            </div>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Objectif</Label>
+              <Textarea
+                value={newEntry.objective}
+                rows={3}
+                placeholder="Décrivez l'objectif marketing recherché"
+                onChange={(event) => setNewEntry((prev) => ({ ...prev, objective: event.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Notes internes</Label>
+              <Textarea
+                value={newEntry.notes}
+                rows={3}
+                placeholder="Contraintes, CTA, assets à prévoir..."
+                onChange={(event) => setNewEntry((prev) => ({ ...prev, notes: event.target.value }))}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Statut</Label>
+            <Select
+              value={newEntry.status}
+              onValueChange={(value: EditorialCalendarStatus) =>
+                setNewEntry((prev) => ({ ...prev, status: value }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUS_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button onClick={addEntry} className="w-full sm:w-auto">
+            <Plus className="mr-2 h-4 w-4" /> Ajouter au planning
+          </Button>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-4">
+        {STATUS_OPTIONS.map((statusOption) => {
+          const items = entries.filter((entry) => entry.status === statusOption.value);
+          return (
+            <DashboardEditableListSection
+              key={statusOption.value}
+              title={statusOption.label}
+              description={STATUS_DESCRIPTIONS[statusOption.value]}
+              items={items}
+              getItemKey={(entry) => entry.id}
+              itemClassName="space-y-3"
+              emptyState={
+                <p className="text-sm text-muted-foreground">
+                  Aucun contenu dans cette étape pour le moment.
+                </p>
+              }
+              renderItem={(entry) => (
+                <div className="space-y-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="space-y-1">
+                      <Input
+                        value={entry.title}
+                        onChange={(event) => updateEntry(entry.id, "title", event.target.value)}
+                      />
+                      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                        <span>{entry.contentType}</span>
+                        {entry.channel ? <Badge variant="outline">{entry.channel}</Badge> : null}
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="text-muted-foreground hover:text-destructive"
+                      onClick={() => removeEntry(entry.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">Date</Label>
+                      <Input
+                        type="date"
+                        value={entry.publishDate ?? ""}
+                        onChange={(event) => updateEntry(entry.id, "publishDate", event.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">Responsable</Label>
+                      <Input
+                        value={entry.owner ?? ""}
+                        onChange={(event) => updateEntry(entry.id, "owner", event.target.value)}
+                      />
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Objectif</Label>
+                    <Textarea
+                      value={entry.objective ?? ""}
+                      rows={3}
+                      placeholder="Angle, KPI ou offre mise en avant"
+                      onChange={(event) => updateEntry(entry.id, "objective", event.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Notes internes</Label>
+                    <Textarea
+                      value={entry.notes ?? ""}
+                      rows={3}
+                      placeholder="Brief créatif, ressources, messages clés"
+                      onChange={(event) => updateEntry(entry.id, "notes", event.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">Statut</Label>
+                    <Select
+                      value={entry.status}
+                      onValueChange={(value: EditorialCalendarStatus) =>
+                        updateEntry(entry.id, "status", value)
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {STATUS_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+              )}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/tools/ideas/page.tsx
+++ b/app/dashboard/tools/ideas/page.tsx
@@ -5,6 +5,8 @@ import { Lightbulb, Plus, Target, Trash2, Trophy } from "lucide-react";
 
 import { useAuth } from "@/contexts/AuthContext";
 import { AuthGuard } from "@/components/auth/AuthGuard";
+import { DashboardEditableListSection } from "@/components/dashboard/DashboardEditableListSection";
+import { DashboardStatCard } from "@/components/dashboard/DashboardStatCard";
 import {
   Card,
   CardContent,
@@ -34,6 +36,13 @@ const STATUS_OPTIONS: { value: NonNullable<IdeaBacklogItem["status"]>; label: st
   { value: "approved", label: "Prêtes" },
   { value: "published", label: "Publiées" },
 ];
+
+const STATUS_DESCRIPTIONS: Record<NonNullable<IdeaBacklogItem["status"]>, string> = {
+  new: "Idées à clarifier et prioriser.",
+  "in-progress": "Briefs en cours de structuration.",
+  approved: "Validées pour lancement.",
+  published: "Déjà publiées ou diffusées.",
+};
 
 const IMPACT_LABELS: Record<NonNullable<IdeaBacklogItem["impact"]>, string> = {
   high: "Fort", 
@@ -243,44 +252,26 @@ export default function IdeasBacklogPage() {
         </Button>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Total d'idées</CardTitle>
-            <Lightbulb className="h-5 w-5 text-primary" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{ideas.length}</div>
-            <p className="text-xs text-muted-foreground">
-              {ideas.length ? "Idées enregistrées" : "Ajoutez votre première idée"}
-            </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Idées en cours</CardTitle>
-            <Target className="h-5 w-5 text-primary" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{statusCounts["in-progress"] ?? 0}</div>
-            <p className="text-xs text-muted-foreground">Suivi opérationnel</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Idées prêtes</CardTitle>
-            <Trophy className="h-5 w-5 text-primary" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{statusCounts["approved"] ?? 0}</div>
-            <p className="text-xs text-muted-foreground">Prêtes à passer en production</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Canaux clés</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <DashboardStatCard
+            title="Total d'idées"
+            value={ideas.length}
+            subtitle={ideas.length ? "Idées enregistrées" : "Ajoutez votre première idée"}
+            icon={Lightbulb}
+          />
+          <DashboardStatCard
+            title="Idées en cours"
+            value={statusCounts["in-progress"] ?? 0}
+            subtitle="Suivi opérationnel"
+            icon={Target}
+          />
+          <DashboardStatCard
+            title="Idées prêtes"
+            value={statusCounts["approved"] ?? 0}
+            subtitle="Prêtes à passer en production"
+            icon={Trophy}
+          />
+          <DashboardStatCard title="Canaux clés">
             {recommendedChannels.length ? (
               <div className="flex flex-wrap gap-2">
                 {recommendedChannels.map((channel) => (
@@ -294,9 +285,8 @@ export default function IdeasBacklogPage() {
                 Aucun canal dominant identifié pour le moment.
               </p>
             )}
-          </CardContent>
-        </Card>
-      </div>
+          </DashboardStatCard>
+        </div>
 
       <Card>
         <CardHeader>
@@ -388,133 +378,126 @@ export default function IdeasBacklogPage() {
         </CardContent>
       </Card>
 
-      <div className="grid gap-6 lg:grid-cols-4">
-        {STATUS_OPTIONS.map((statusOption) => {
-          const items = ideas.filter((idea) => idea.status === statusOption.value);
-          return (
-            <Card key={statusOption.value} className="flex flex-col">
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center justify-between text-base font-semibold">
-                  <span>{statusOption.label}</span>
-                  <Badge variant="outline">{items.length}</Badge>
-                </CardTitle>
-                <CardDescription>
-                  {statusOption.value === "new" && "Idées à clarifier et prioriser."}
-                  {statusOption.value === "in-progress" && "Briefs en cours de structuration."}
-                  {statusOption.value === "approved" && "Validées pour lancement."}
-                  {statusOption.value === "published" && "Déjà publiées ou diffusées."}
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4 flex-1">
-                {items.length ? (
-                  items.map((idea) => (
-                    <div key={idea.id} className="rounded-lg border p-4 space-y-3">
-                      <div className="flex items-start justify-between gap-2">
-                        <Input
-                          value={idea.topic}
-                          onChange={(event) => updateIdea(idea.id, "topic", event.target.value)}
-                        />
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="text-muted-foreground hover:text-destructive"
-                          onClick={() => removeIdea(idea.id)}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
+        <div className="grid gap-6 lg:grid-cols-4">
+          {STATUS_OPTIONS.map((statusOption) => {
+            const items = ideas.filter((idea) => idea.status === statusOption.value);
+            return (
+              <DashboardEditableListSection
+                key={statusOption.value}
+                title={statusOption.label}
+                description={STATUS_DESCRIPTIONS[statusOption.value]}
+                items={items}
+                getItemKey={(idea) => idea.id}
+                itemClassName="space-y-3"
+                emptyState={
+                  <p className="text-sm text-muted-foreground">
+                    Aucune idée dans cette étape pour le moment.
+                  </p>
+                }
+                renderItem={(idea) => (
+                  <div className="space-y-3">
+                    <div className="flex items-start justify-between gap-2">
+                      <Input
+                        value={idea.topic}
+                        onChange={(event) => updateIdea(idea.id, "topic", event.target.value)}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-destructive"
+                        onClick={() => removeIdea(idea.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                        <span>
+                          Créée le {new Date(idea.createdAt).toLocaleDateString("fr-FR")}
+                        </span>
+                        {idea.objective ? (
+                          <Badge variant="secondary">Objectif défini</Badge>
+                        ) : null}
                       </div>
-                      <div className="space-y-2">
-                        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-                          <span>Créée le {new Date(idea.createdAt).toLocaleDateString("fr-FR")}</span>
-                          {idea.objective ? (
-                            <Badge variant="secondary">Objectif défini</Badge>
-                          ) : null}
-                        </div>
-                        <Label className="text-xs text-muted-foreground">Canal</Label>
-                        <Input
-                          value={idea.channel ?? ""}
-                          onChange={(event) => updateIdea(idea.id, "channel", event.target.value)}
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label className="text-xs text-muted-foreground">Objectif</Label>
-                        <Textarea
-                          value={idea.objective ?? ""}
-                          rows={3}
-                          placeholder="Décrire l'angle ou le résultat attendu"
-                          onChange={(event) => updateIdea(idea.id, "objective", event.target.value)}
-                        />
-                      </div>
-                      <div className="grid gap-3 sm:grid-cols-2">
-                        <div className="space-y-1">
-                          <Label className="text-xs text-muted-foreground">Impact</Label>
-                          <Select
-                            value={idea.impact ?? "medium"}
-                            onValueChange={(value: NonNullable<IdeaBacklogItem["impact"]>) =>
-                              updateIdea(idea.id, "impact", value)
-                            }
-                          >
-                            <SelectTrigger>
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="high">{IMPACT_LABELS.high}</SelectItem>
-                              <SelectItem value="medium">{IMPACT_LABELS.medium}</SelectItem>
-                              <SelectItem value="low">{IMPACT_LABELS.low}</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </div>
-                        <div className="space-y-1">
-                          <Label className="text-xs text-muted-foreground">Effort</Label>
-                          <Select
-                            value={idea.effort ?? "medium"}
-                            onValueChange={(value: NonNullable<IdeaBacklogItem["effort"]>) =>
-                              updateIdea(idea.id, "effort", value)
-                            }
-                          >
-                            <SelectTrigger>
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="low">{EFFORT_LABELS.low}</SelectItem>
-                              <SelectItem value="medium">{EFFORT_LABELS.medium}</SelectItem>
-                              <SelectItem value="high">{EFFORT_LABELS.high}</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </div>
-                      </div>
-                      <div className="space-y-2">
-                        <Label className="text-xs text-muted-foreground">Statut</Label>
+                      <Label className="text-xs text-muted-foreground">Canal</Label>
+                      <Input
+                        value={idea.channel ?? ""}
+                        onChange={(event) => updateIdea(idea.id, "channel", event.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label className="text-xs text-muted-foreground">Objectif</Label>
+                      <Textarea
+                        value={idea.objective ?? ""}
+                        rows={3}
+                        placeholder="Décrire l'angle ou le résultat attendu"
+                        onChange={(event) => updateIdea(idea.id, "objective", event.target.value)}
+                      />
+                    </div>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <div className="space-y-1">
+                        <Label className="text-xs text-muted-foreground">Impact</Label>
                         <Select
-                          value={idea.status ?? "new"}
-                          onValueChange={(value: NonNullable<IdeaBacklogItem["status"]>) =>
-                            updateIdea(idea.id, "status", value)
+                          value={idea.impact ?? "medium"}
+                          onValueChange={(value: NonNullable<IdeaBacklogItem["impact"]>) =>
+                            updateIdea(idea.id, "impact", value)
                           }
                         >
                           <SelectTrigger>
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
-                            {STATUS_OPTIONS.map((option) => (
-                              <SelectItem key={option.value} value={option.value}>
-                                {option.label}
-                              </SelectItem>
-                            ))}
+                            <SelectItem value="high">{IMPACT_LABELS.high}</SelectItem>
+                            <SelectItem value="medium">{IMPACT_LABELS.medium}</SelectItem>
+                            <SelectItem value="low">{IMPACT_LABELS.low}</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="space-y-1">
+                        <Label className="text-xs text-muted-foreground">Effort</Label>
+                        <Select
+                          value={idea.effort ?? "medium"}
+                          onValueChange={(value: NonNullable<IdeaBacklogItem["effort"]>) =>
+                            updateIdea(idea.id, "effort", value)
+                          }
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="low">{EFFORT_LABELS.low}</SelectItem>
+                            <SelectItem value="medium">{EFFORT_LABELS.medium}</SelectItem>
+                            <SelectItem value="high">{EFFORT_LABELS.high}</SelectItem>
                           </SelectContent>
                         </Select>
                       </div>
                     </div>
-                  ))
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    Aucune idée dans cette étape pour le moment.
-                  </p>
+                    <div className="space-y-2">
+                      <Label className="text-xs text-muted-foreground">Statut</Label>
+                      <Select
+                        value={idea.status ?? "new"}
+                        onValueChange={(value: NonNullable<IdeaBacklogItem["status"]>) =>
+                          updateIdea(idea.id, "status", value)
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {STATUS_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
                 )}
-              </CardContent>
-            </Card>
-          );
-        })}
-      </div>
+              />
+            );
+          })}
+        </div>
 
       {prioritizedIdeas.length ? (
         <Card>

--- a/components/dashboard/DashboardEditableListSection.tsx
+++ b/components/dashboard/DashboardEditableListSection.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { Key, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface DashboardEditableListSectionProps<T> {
+  title: string;
+  description?: ReactNode;
+  items: T[];
+  renderItem: (item: T, index: number) => ReactNode;
+  getItemKey?: (item: T, index: number) => Key;
+  emptyState?: ReactNode;
+  badge?: ReactNode | number | null;
+  className?: string;
+  itemClassName?: string;
+}
+
+export function DashboardEditableListSection<T>({
+  title,
+  description,
+  items,
+  renderItem,
+  getItemKey,
+  emptyState,
+  badge,
+  className,
+  itemClassName,
+}: DashboardEditableListSectionProps<T>) {
+  const badgeContent =
+    badge === null
+      ? null
+      : typeof badge === "number"
+        ? badge >= 0
+          ? (
+              <Badge variant="outline">{badge}</Badge>
+            )
+          : null
+        : badge ?? <Badge variant="outline">{items.length}</Badge>;
+
+  return (
+    <Card className={cn("flex flex-col", className)}>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center justify-between text-base font-semibold">
+          <span>{title}</span>
+          {badgeContent}
+        </CardTitle>
+        {description ? <CardDescription>{description}</CardDescription> : null}
+      </CardHeader>
+      <CardContent className="flex-1 space-y-4">
+        {items.length ? (
+          items.map((item, index) => (
+            <div
+              key={getItemKey ? getItemKey(item, index) : index}
+              className={cn("rounded-lg border p-4", itemClassName)}
+            >
+              {renderItem(item, index)}
+            </div>
+          ))
+        ) : (
+          emptyState ?? (
+            <p className="text-sm text-muted-foreground">
+              Aucun élément à afficher pour le moment.
+            </p>
+          )
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/dashboard/DashboardStatCard.tsx
+++ b/components/dashboard/DashboardStatCard.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface DashboardStatCardProps {
+  title: string;
+  description?: ReactNode;
+  value?: ReactNode;
+  subtitle?: ReactNode;
+  icon?: LucideIcon;
+  meta?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+  contentClassName?: string;
+}
+
+export function DashboardStatCard({
+  title,
+  description,
+  value,
+  subtitle,
+  icon: Icon,
+  meta,
+  children,
+  className,
+  contentClassName,
+}: DashboardStatCardProps) {
+  return (
+    <Card className={cn(className)}>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
+        <div className="space-y-1">
+          <CardTitle className="text-sm font-medium">{title}</CardTitle>
+          {description ? <CardDescription>{description}</CardDescription> : null}
+        </div>
+        {meta ?? (Icon ? <Icon className="h-5 w-5 text-primary" /> : null)}
+      </CardHeader>
+      <CardContent className={cn("space-y-2", contentClassName)}>
+        {value !== undefined ? (
+          <div className="text-2xl font-bold leading-none tracking-tight">{value}</div>
+        ) : null}
+        {subtitle ? <p className="text-xs text-muted-foreground">{subtitle}</p> : null}
+        {children}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -35,6 +35,81 @@ export interface ComplianceConfig {
   requestContactEmail?: string;
 }
 
+export interface IdeaBacklogItem {
+  id: string;
+  topic: string;
+  channel?: string;
+  objective?: string;
+  impact?: "high" | "medium" | "low";
+  effort?: "high" | "medium" | "low";
+  status?: "new" | "in-progress" | "approved" | "published";
+  createdAt: string;
+  updatedAt?: string;
+  tags?: string[];
+}
+
+export type EditorialCalendarStatus =
+  | "draft"
+  | "in-production"
+  | "scheduled"
+  | "published";
+
+export interface EditorialCalendarEntry {
+  id: string;
+  title: string;
+  channel: string;
+  contentType?: string;
+  owner?: string;
+  status: EditorialCalendarStatus;
+  publishDate: string;
+  objective?: string;
+  notes?: string;
+  assets?: string[];
+}
+
+export type BrandGuidelineCategory =
+  | "voice"
+  | "visual"
+  | "messaging"
+  | "campaign"
+  | "compliance"
+  | "other";
+
+export interface BrandGuideline {
+  id: string;
+  title: string;
+  category: BrandGuidelineCategory;
+  description: string;
+  owner?: string;
+  assets?: string[];
+  toneKeywords?: string[];
+  updatedAt: string;
+}
+
+export interface AudiencePersona {
+  id: string;
+  name: string;
+  segment?: string;
+  description?: string;
+  pains?: string[];
+  goals?: string[];
+  preferredChannels?: string[];
+  stage?: "awareness" | "consideration" | "decision" | "retention";
+  notes?: string;
+}
+
+export interface AIModelConfig {
+  id: string;
+  name: string;
+  provider: string;
+  useCase: string;
+  status: "active" | "paused";
+  temperature?: number;
+  maxTokens?: number;
+  lastTrainedAt?: string;
+  instructions?: string;
+}
+
 export interface Organization {
   $id: string;
   name: string;
@@ -47,6 +122,11 @@ export interface Organization {
   teamId?: string;
   supportCenter?: SupportCenterConfig;
   compliance?: ComplianceConfig;
+  ideaBacklog?: IdeaBacklogItem[];
+  editorialCalendar?: EditorialCalendarEntry[];
+  brandGuidelines?: BrandGuideline[];
+  audiencePersonas?: AudiencePersona[];
+  aiModelConfigs?: AIModelConfig[];
 }
 
 export class AuthService {
@@ -186,6 +266,11 @@ export class AuthService {
             complianceArtifacts: [],
             requestContactEmail: "",
           },
+          ideaBacklog: [],
+          editorialCalendar: [],
+          brandGuidelines: [],
+          audiencePersonas: [],
+          aiModelConfigs: [],
         }
       );
 

--- a/lib/navigation-data.ts
+++ b/lib/navigation-data.ts
@@ -219,27 +219,27 @@ export const contentCreation: NavigationItem[] = [
 export const managementTools: NavigationItem[] = [
   {
     title: "Content Calendar",
-    url: "/tools/calendar",
+    url: "/dashboard/tools/calendar",
     icon: Calendar,
   },
   {
     title: "Brand Guidelines",
-    url: "/tools/brand",
+    url: "/dashboard/tools/brand",
     icon: Palette,
   },
   {
     title: "Target Audiences",
-    url: "/tools/audiences",
+    url: "/dashboard/tools/audiences",
     icon: Users,
   },
   {
     title: "AI Models",
-    url: "/tools/ai-models",
+    url: "/dashboard/tools/ai-models",
     icon: Bot,
   },
   {
     title: "Content Ideas",
-    url: "/tools/ideas",
+    url: "/dashboard/tools/ideas",
     icon: Lightbulb,
   },
 ];


### PR DESCRIPTION
## Summary
- prefix management tool navigation entries with the protected dashboard route
- extend Auth types for calendars, brand kits, personas and AI models and add shared dashboard components
- implement calendar, brand, audience and AI model management pages that persist data via Appwrite and reuse the shared UI in the ideas backlog

## Testing
- npm run lint *(fails: ESLint is not installed in the project environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7157cc7748323aa1aec8a64728437