### PR TITLE
Refine page flows for a streamlined UX

### DIFF
--- a/app/branding/page.tsx
+++ b/app/branding/page.tsx
@@ -6,10 +6,7 @@ import {
   Upload,
   Palette,
   MessageSquare,
-  ArrowRight,
-  ArrowLeft,
   Sparkles,
-  Check,
   ArrowUpLeft,
   ArrowUpRight,
 } from "lucide-react";
@@ -17,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { BackgroundBeams } from "@/components/ui/background-beams";
 import { Spotlight } from "@/components/ui/spotlight";
 import Image from "next/image";
@@ -106,291 +103,280 @@ export default function Branding() {
   };
 
   return (
-    <div className="min-h-screen bg-black/[0.96] antialiased bg-grid-white/[0.02] relative overflow-hidden">
-      {/* Background Effects */}
-      <Spotlight
-        className="-top-40 left-0 md:left-60 md:-top-20"
-        fill="white"
-      />
+    <div className="relative min-h-screen overflow-hidden bg-black/[0.96] bg-grid-white/[0.02] antialiased">
+      <Spotlight className="-top-40 left-0 md:left-60 md:-top-20" fill="white" />
       <BackgroundBeams />
 
       <div className="relative z-10 container mx-auto px-4 py-12">
-        {/* Header */}
-        <div
-          className={` mb-16 transition-all duration-1000 ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"}`}
-        >
-          <div className="inline-flex items-center space-x-3 mb-6">
-            <Sparkles className="w-6 h-6 text-blue-500" />
-            <h1 className="text-4xl md:text-6xl font-bold bg-clip-text text-transparent bg-gradient-to-b from-neutral-50 to-neutral-400">
-              Branding
+        <div className={`mx-auto max-w-6xl space-y-10 transition-all duration-700 ${isVisible ? "opacity-100 translate-y-0" : "translate-y-6 opacity-0"}`}>
+          <header className="text-center space-y-4">
+            <div className="flex items-center justify-center gap-3 text-blue-300">
+              <Sparkles className="h-5 w-5" />
+              <span className="text-sm font-semibold uppercase tracking-wide">
+                Identité de campagne
+              </span>
+            </div>
+            <h1 className="text-4xl font-semibold text-neutral-50 md:text-5xl">
+              Personnalisez votre univers de marque
             </h1>
-          </div>
+            <p className="text-lg text-neutral-300">
+              Alignez ton, palette et assets pour guider la génération de contenu Postgen AI.
+            </p>
+            {topic && (
+              <div className="mx-auto inline-flex items-center gap-2 rounded-full border border-neutral-800 bg-neutral-950/60 px-5 py-2 text-sm text-blue-300">
+                <span className="h-2 w-2 animate-pulse rounded-full bg-blue-500" />
+                {topic}
+              </div>
+            )}
+          </header>
 
-          <p className="text-xl text-neutral-300 mb-6">
-            Définissez l&apos;identité de votre contenu
-          </p>
+          <div className="grid gap-10 xl:grid-cols-[minmax(0,420px)_minmax(0,1fr)] xl:items-start">
+            <form className="space-y-6" onSubmit={(e) => e.preventDefault()}>
+              <Card className="border-neutral-800 bg-neutral-950/60 backdrop-blur">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-neutral-100">
+                    <Upload className="h-5 w-5 text-blue-400" />
+                    Logo et assets
+                  </CardTitle>
+                  <CardDescription className="text-neutral-400">
+                    Importez votre logo pour que Postgen AI réutilise vos visuels clés.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="relative">
+                    <div className="relative overflow-hidden rounded-2xl border-2 border-dashed border-neutral-800 bg-neutral-900/60 p-8 text-center transition hover:border-blue-500/60">
+                      {logo ? (
+                        <div className="space-y-4">
+                          <Image src={logo} alt="Logo" width={100} height={100} className="mx-auto max-h-24 rounded-xl shadow" />
+                          <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => setLogo(null)}
+                            className="border-neutral-800 text-neutral-200 hover:bg-neutral-800"
+                          >
+                            Retirer le logo
+                          </Button>
+                        </div>
+                      ) : (
+                        <div className="space-y-4 text-neutral-400">
+                          <Upload className="mx-auto h-10 w-10" />
+                          <div>
+                            <p className="font-medium text-neutral-200">Déposez votre logo</p>
+                            <p className="text-sm">PNG, JPG ou SVG · 5MB max</p>
+                          </div>
+                        </div>
+                      )}
+                      <input
+                        type="file"
+                        accept="image/*"
+                        onChange={handleLogoUpload}
+                        className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                      />
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
 
-          <div className="inline-flex items-center space-x-3 bg-neutral-950/50 backdrop-blur-xl border border-neutral-800 rounded-full px-6 py-3">
-            <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse" />
-            <span className="text-blue-400 font-medium">
-              &quot;{topic}&quot;
-            </span>
-          </div>
-        </div>
+              <Card className="border-neutral-800 bg-neutral-950/60 backdrop-blur">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-neutral-100">
+                    <Palette className="h-5 w-5 text-violet-400" />
+                    Palette de couleurs
+                  </CardTitle>
+                  <CardDescription className="text-neutral-400">
+                    Sélectionnez des presets ou affinez vos codes hexadécimaux.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <div className="grid grid-cols-3 gap-3">
+                    {colorPresets.map((preset) => (
+                      <button
+                        key={preset.name}
+                        type="button"
+                        onClick={() => selectColorPreset(preset)}
+                        className={`rounded-xl border px-3 py-2 text-left text-xs text-neutral-300 transition hover:border-violet-500 ${
+                          primaryColor === preset.primary && secondaryColor === preset.secondary
+                            ? "border-violet-500 bg-violet-500/10"
+                            : "border-neutral-800 bg-neutral-900/60"
+                        }`}
+                      >
+                        <div className="mb-2 flex gap-2">
+                          <span
+                            className="h-5 w-5 rounded-md"
+                            style={{ backgroundColor: preset.primary }}
+                          />
+                          <span
+                            className="h-5 w-5 rounded-md"
+                            style={{ backgroundColor: preset.secondary }}
+                          />
+                        </div>
+                        {preset.name}
+                      </button>
+                    ))}
+                  </div>
 
-        <div
-          className={`max-w-6xl mx-auto grid lg:grid-cols-3 gap-8 transition-all duration-1000 delay-300 ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"}`}
-        >
-          {/* Logo Upload */}
-          <Card className="group hover:shadow-lg hover:shadow-blue-500/10 transition-all duration-300 bg-neutral-950/50 backdrop-blur-xl border-neutral-800">
-            <CardHeader>
-              <CardTitle className="flex items-center space-x-3 text-neutral-100">
-                <div className="w-10 h-10 bg-blue-950/50 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform">
-                  <Upload className="w-5 h-5 text-blue-400" />
-                </div>
-                <span>Logo</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="relative">
-                <div className="border-2 border-dashed border-neutral-700 rounded-2xl p-8 text-center hover:border-blue-500/50 transition-all duration-300 relative overflow-hidden group/upload">
-                  {logo ? (
-                    <div className="space-y-4">
-                      <div className="relative inline-block">
-                        <Image
-                          src={logo}
-                          alt="Logo"
-                          width={100}
-                          height={100}
-                          className="max-h-24 mx-auto rounded-xl shadow-lg"
+                  <div className="space-y-4 text-sm text-neutral-300">
+                    <div className="space-y-2">
+                      <Label>Couleur primaire</Label>
+                      <div className="flex items-center gap-3">
+                        <input
+                          type="color"
+                          value={primaryColor}
+                          onChange={(e) => setPrimaryColor(e.target.value)}
+                          className="h-12 w-12 cursor-pointer rounded-lg border border-neutral-700"
+                        />
+                        <Input
+                          value={primaryColor}
+                          onChange={(e) => setPrimaryColor(e.target.value)}
+                          className="w-full border-neutral-800 bg-neutral-900/60 font-mono text-sm"
                         />
                       </div>
-                      <Button
-                        variant="outline"
-                        onClick={() => setLogo(null)}
-                        className="border-neutral-700 hover:border-blue-500 hover:text-blue-400"
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Couleur secondaire</Label>
+                      <div className="flex items-center gap-3">
+                        <input
+                          type="color"
+                          value={secondaryColor}
+                          onChange={(e) => setSecondaryColor(e.target.value)}
+                          className="h-12 w-12 cursor-pointer rounded-lg border border-neutral-700"
+                        />
+                        <Input
+                          value={secondaryColor}
+                          onChange={(e) => setSecondaryColor(e.target.value)}
+                          className="w-full border-neutral-800 bg-neutral-900/60 font-mono text-sm"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="border-neutral-800 bg-neutral-950/60 backdrop-blur">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-neutral-100">
+                    <MessageSquare className="h-5 w-5 text-emerald-400" />
+                    Ton éditorial
+                  </CardTitle>
+                  <CardDescription className="text-neutral-400">
+                    Choisissez l'attitude qui représentera votre marque sur chaque canal.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <RadioGroup value={tone} onValueChange={setTone} className="space-y-3">
+                    {toneOptions.map((option) => (
+                      <label
+                        key={option.value}
+                        htmlFor={option.value}
+                        className={`flex cursor-pointer items-center gap-4 rounded-xl border p-4 transition hover:border-emerald-500 ${
+                          tone === option.value
+                            ? "border-emerald-500 bg-emerald-500/10"
+                            : "border-neutral-800 bg-neutral-900/60"
+                        }`}
                       >
-                        Changer le logo
-                      </Button>
-                    </div>
-                  ) : (
-                    <div className="space-y-4">
-                      <Upload className="w-12 h-12 text-neutral-400 mx-auto group-hover/upload:text-blue-500 transition-colors" />
-                      <div>
-                        <p className="text-neutral-300 font-medium">
-                          Ajoutez votre logo
-                        </p>
-                        <p className="text-neutral-500 text-sm mt-1">
-                          PNG, JPG, SVG • Max 5MB
-                        </p>
-                      </div>
-                    </div>
-                  )}
+                        <RadioGroupItem
+                          value={option.value}
+                          id={option.value}
+                          className="border-neutral-400 text-emerald-400"
+                        />
+                        <div>
+                          <p className="text-sm font-semibold text-neutral-100">
+                            {option.icon} {option.label}
+                          </p>
+                          <p className="text-xs text-neutral-400">{option.description}</p>
+                        </div>
+                      </label>
+                    ))}
+                  </RadioGroup>
+                </CardContent>
+              </Card>
+            </form>
 
-                  <input
-                    type="file"
-                    accept="image/*"
-                    onChange={handleLogoUpload}
-                    className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
-                  />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Color Palette */}
-          <Card className="group hover:shadow-lg hover:shadow-violet-500/10 transition-all duration-300 bg-neutral-950/50 backdrop-blur-xl border-neutral-800">
-            <CardHeader>
-              <CardTitle className="flex items-center space-x-3 text-neutral-100">
-                <div className="w-10 h-10 bg-violet-950/50 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform">
-                  <Palette className="w-5 h-5 text-violet-400" />
-                </div>
-                <span>Couleurs</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              {/* Color Presets */}
-              <div className="grid grid-cols-3 gap-3">
-                {colorPresets.map((preset) => (
-                  <button
-                    key={preset.name}
-                    onClick={() => selectColorPreset(preset)}
-                    className="group/preset relative p-3 rounded-xl border border-neutral-700 hover:border-neutral-600 transition-all duration-300 hover:scale-105"
-                  >
-                    <div className="flex space-x-2 mb-2">
-                      <div
-                        className="w-6 h-6 rounded-lg shadow-sm"
-                        style={{ backgroundColor: preset.primary }}
+            <div className="space-y-6">
+              <Card className="border-neutral-800 bg-neutral-950/60 backdrop-blur">
+                <CardHeader>
+                  <CardTitle className="text-neutral-100">Aperçu instantané</CardTitle>
+                  <CardDescription className="text-neutral-400">
+                    Visualisez comment Postgen AI utilisera vos choix de branding.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <div className="flex flex-wrap items-center justify-center gap-6">
+                    {logo && (
+                      <Image src={logo} alt="Logo" width={96} height={96} className="rounded-xl border border-neutral-800 bg-white/10 p-4" />
+                    )}
+                    <div className="flex gap-3">
+                      <span
+                        className="h-12 w-12 rounded-lg border border-neutral-700"
+                        style={{ backgroundColor: primaryColor }}
                       />
-                      <div
-                        className="w-6 h-6 rounded-lg shadow-sm"
-                        style={{ backgroundColor: preset.secondary }}
+                      <span
+                        className="h-12 w-12 rounded-lg border border-neutral-700"
+                        style={{ backgroundColor: secondaryColor }}
                       />
                     </div>
-                    <span className="text-xs text-neutral-400 font-medium">
-                      {preset.name}
-                    </span>
-                  </button>
-                ))}
-              </div>
-
-              {/* Custom Colors */}
-              <div className="space-y-4">
-                <div className="space-y-2">
-                  <Label className="text-neutral-300">Couleur Primaire</Label>
-                  <div className="flex items-center space-x-3">
-                    <input
-                      type="color"
-                      value={primaryColor}
-                      onChange={(e) => setPrimaryColor(e.target.value)}
-                      className="w-12 h-12 rounded-lg border border-neutral-700 cursor-pointer"
-                    />
-                    <Input
-                      value={primaryColor}
-                      onChange={(e) => setPrimaryColor(e.target.value)}
-                      className="font-mono text-sm bg-neutral-900/50 border-neutral-700 text-neutral-300"
-                    />
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <Label className="text-neutral-300">Couleur Secondaire</Label>
-                  <div className="flex items-center space-x-3">
-                    <input
-                      type="color"
-                      value={secondaryColor}
-                      onChange={(e) => setSecondaryColor(e.target.value)}
-                      className="w-12 h-12 rounded-lg border border-neutral-700 cursor-pointer"
-                    />
-                    <Input
-                      value={secondaryColor}
-                      onChange={(e) => setSecondaryColor(e.target.value)}
-                      className="font-mono text-sm bg-neutral-900/50 border-neutral-700 text-neutral-300"
-                    />
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Tone Selection */}
-          <Card className="group hover:shadow-lg hover:shadow-emerald-500/10 transition-all duration-300 bg-neutral-950/50 backdrop-blur-xl border-neutral-800">
-            <CardHeader>
-              <CardTitle className="flex items-center space-x-3 text-neutral-100">
-                <div className="w-10 h-10 bg-emerald-950/50 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform">
-                  <MessageSquare className="w-5 h-5 text-emerald-400" />
-                </div>
-                <span>Ton</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <RadioGroup
-                value={tone}
-                onValueChange={setTone}
-                className="space-y-3"
-              >
-                {toneOptions.map((option) => (
-                  <div key={option.value} className="relative group/tone">
-                    <div className="flex items-center space-x-4 p-4 rounded-xl border border-neutral-700 hover:border-neutral-600 transition-all cursor-pointer group-hover/tone:shadow-sm">
-                      <RadioGroupItem
-                        value={option.value}
-                        id={option.value}
-                        className="border-neutral-400 text-blue-600"
-                      />
-                      <div className="text-xl">{option.icon}</div>
-                      <div className="flex-1">
-                        <Label
-                          htmlFor={option.value}
-                          className="text-neutral-100 font-medium cursor-pointer"
-                        >
-                          {option.label}
-                        </Label>
-                        <p className="text-neutral-500 text-sm mt-0.5">
-                          {option.description}
-                        </p>
-                      </div>
-                      {tone === option.value && (
-                        <Check className="w-4 h-4 text-blue-400" />
-                      )}
+                    <div className="text-center text-neutral-200">
+                      <p className="text-lg font-semibold">
+                        {toneOptions.find((t) => t.value === tone)?.icon}{" "}
+                        {toneOptions.find((t) => t.value === tone)?.label}
+                      </p>
+                      <p className="text-sm text-neutral-400">
+                        {toneOptions.find((t) => t.value === tone)?.description}
+                      </p>
                     </div>
                   </div>
-                ))}
-              </RadioGroup>
-            </CardContent>
-          </Card>
-        </div>
 
-        {/* Preview */}
-        <div
-          className={`mt-16 max-w-4xl mx-auto transition-all duration-1000 delay-500 ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"}`}
-        >
-          <Card className="bg-neutral-950/50 backdrop-blur-xl border-neutral-800">
-            <CardHeader>
-              <CardTitle className="text-center text-neutral-100">
-                Aperçu de votre identité
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-center justify-center space-x-8 p-8">
-                {logo && (
-                  <div className="relative">
-                    <Image
-                      src={logo}
-                      alt="Logo"
-                      width={100}
-                      height={100}
-                      className=" shadow-sm"
-                    />
+                  <div className="grid gap-4 rounded-2xl border border-neutral-800 bg-neutral-900/50 p-6 text-sm text-neutral-300">
+                    <div className="flex items-center justify-between">
+                      <span>Campagne</span>
+                      <span className="font-medium text-neutral-100">{topic || "Définissez votre sujet"}</span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span>Tonalité</span>
+                      <span className="font-medium text-neutral-100">
+                        {toneOptions.find((t) => t.value === tone)?.label}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span>Couleurs</span>
+                      <span className="font-mono text-xs text-neutral-400">
+                        {primaryColor} / {secondaryColor}
+                      </span>
+                    </div>
                   </div>
-                )}
+                </CardContent>
+              </Card>
 
-                <div className="flex space-x-3">
-                  <div
-                    className="w-12 h-12 rounded-lg shadow-sm border border-neutral-700"
-                    style={{ backgroundColor: primaryColor }}
-                  />
-                  <div
-                    className="w-12 h-12 rounded-lg shadow-sm border border-neutral-700"
-                    style={{ backgroundColor: secondaryColor }}
-                  />
-                </div>
-
-                <div className="text-center">
-                  <div className="text-neutral-100 font-semibold text-lg mb-1">
-                    {toneOptions.find((t) => t.value === tone)?.icon}{" "}
-                    {toneOptions.find((t) => t.value === tone)?.label}
+              <Card className="border-neutral-800 bg-neutral-950/60 backdrop-blur">
+                <CardHeader>
+                  <CardTitle className="text-neutral-100">Étapes suivantes</CardTitle>
+                  <CardDescription className="text-neutral-400">
+                    Une fois satisfait, passez à la génération de contenu multi-format.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm text-neutral-300">
+                  <p>
+                    Vous pourrez toujours ajuster ces paramètres depuis le dashboard. Ils alimentent vos briefs, prompts et modèles de carrousel.
+                  </p>
+                  <div className="flex flex-wrap justify-between gap-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => router.push("/")}
+                      className="border-neutral-800 bg-black text-neutral-300 hover:text-white"
+                    >
+                      <ArrowUpLeft className="mr-2 h-4 w-4" />
+                      Retour
+                    </Button>
+                    <Button onClick={handleSubmit} className="bg-white text-black hover:bg-neutral-200">
+                      Continuer vers la génération
+                      <ArrowUpRight className="ml-2 h-4 w-4" />
+                    </Button>
                   </div>
-                  <div className="text-neutral-500 text-sm">
-                    {toneOptions.find((t) => t.value === tone)?.description}
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Navigation */}
-        <div
-          className={`flex justify-between items-center mt-16 max-w-4xl mx-auto transition-all duration-1000 delay-700 ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"}`}
-        >
-          <Button
-            variant="outline"
-            onClick={() => router.push("/")}
-            className="border-neutral-700 bg-black text-neutral-300 hover:border-neutral-600 px-6 py-2.5"
-          >
-            <ArrowUpLeft className="w-4 h-4 mr-2" />
-            Retour
-          </Button>
-
-          <Button
-            onClick={handleSubmit}
-            className="bg-white text-black px-8 py-2.5 hover:text-white hover:shadow-lg hover:shadow-blue-500/25 transition-all duration-300"
-          >
-            <span className="flex items-center space-x-2">
-              <span>Continuer</span>
-              <ArrowUpRight className="w-4 h-4" />
-            </span>
-          </Button>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -11,7 +11,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import {
   Alert,
   AlertDescription,
@@ -34,6 +33,7 @@ import { useEngagementInsights } from "@/hooks/useEngagementInsights";
 import { AnalyticsSummaryCards } from "@/components/dashboard/AnalyticsSummaryCards";
 import { EngagementPerformanceChart } from "@/components/dashboard/EngagementPerformanceChart";
 import { TopContentTable } from "@/components/dashboard/TopContentTable";
+import { PageHeader, PageSection, PageShell } from "@/components/ui/page-shell";
 
 const numberFormatter = new Intl.NumberFormat("fr-FR");
 
@@ -131,21 +131,19 @@ export default function Dashboard() {
     : 0;
 
   return (
-    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-      <div className="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
-        <h1 className="text-2xl font-bold mb-2">
-          Bienvenue, {user?.name} ! 👋
-        </h1>
-        <p className="text-muted-foreground mb-4">
-          Vous êtes dans l'organisation <strong>{currentOrganization.name}</strong>. Créez du contenu exceptionnel avec l'IA.
-        </p>
-        <Button asChild>
-          <a href="/generate">
-            <Sparkles className="mr-2 h-4 w-4" />
-            Créer du contenu
-          </a>
-        </Button>
-      </div>
+    <PageShell className="pt-2">
+      <PageHeader
+        title={`Bienvenue, ${user?.name ?? ""} ! 👋`}
+        description={`Vous êtes dans l'organisation ${currentOrganization.name}. Lancez une nouvelle génération ou explorez vos métriques clés.`}
+        actions={
+          <Button asChild>
+            <a href="/generate">
+              <Sparkles className="mr-2 h-4 w-4" />
+              Créer du contenu
+            </a>
+          </Button>
+        }
+      />
 
       {metricsError && (
         <Alert variant="destructive">
@@ -155,9 +153,19 @@ export default function Dashboard() {
         </Alert>
       )}
 
-      <AnalyticsSummaryCards cards={insights?.summaryCards ?? []} />
+      <PageSection
+        title="Vue d'ensemble"
+        description="Survolez les indicateurs essentiels pour suivre vos campagnes en cours."
+        contentClassName="grid gap-4"
+      >
+        <AnalyticsSummaryCards cards={insights?.summaryCards ?? []} />
+      </PageSection>
 
-      <div className="grid gap-4 lg:grid-cols-3">
+      <PageSection
+        title="Performance et objectifs"
+        description="Comparez vos résultats actuels aux repères fixés par votre plan."
+        contentClassName="grid gap-4 lg:grid-cols-3"
+      >
         <EngagementPerformanceChart
           data={insights?.timeseries ?? []}
           loading={loadingMetrics}
@@ -204,18 +212,19 @@ export default function Dashboard() {
             )}
           </CardContent>
         </Card>
-      </div>
+      </PageSection>
 
-      <TopContentTable items={insights?.topContent ?? []} loading={loadingMetrics} />
+      <PageSection
+        title="Contenus qui performent"
+        description="Identifiez vos publications les plus efficaces pour inspirer vos prochaines itérations."
+      >
+        <TopContentTable items={insights?.topContent ?? []} loading={loadingMetrics} />
+      </PageSection>
 
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <div>
-            <CardTitle>Recommandations IA</CardTitle>
-            <CardDescription>
-              Suggestions d'optimisation basées sur vos métriques récentes et votre plan.
-            </CardDescription>
-          </div>
+      <PageSection
+        title="Recommandations IA"
+        description="Laissez l'IA suggérer des actions concrètes à partir de vos dernières métriques."
+        actions={
           <Button
             variant="outline"
             size="sm"
@@ -234,121 +243,113 @@ export default function Dashboard() {
               </>
             )}
           </Button>
-        </CardHeader>
-        <CardContent>
-          {!insights?.metrics?.length ? (
-            <p className="text-sm text-muted-foreground">
-              Publiez du contenu et revenez pour obtenir des recommandations personnalisées.
-            </p>
-          ) : loadingRecommendations ? (
-            <div className="flex items-center justify-center py-6 text-muted-foreground">
-              <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-              Analyse des métriques…
-            </div>
-          ) : recommendationError ? (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>Recommandations indisponibles</AlertTitle>
-              <AlertDescription>{recommendationError}</AlertDescription>
-            </Alert>
-          ) : recommendations.length ? (
-            <ul className="space-y-3 text-sm">
-              {recommendations.map((suggestion, index) => (
-                <li
-                  key={`${suggestion}-${index}`}
-                  className="flex items-start gap-2 rounded-md border border-dashed border-muted-foreground/40 bg-muted/40 p-3"
-                >
-                  <Sparkles className="mt-0.5 h-4 w-4 text-primary" />
-                  <span>{suggestion}</span>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <div className="text-sm text-muted-foreground">
-              Cliquez sur « Générer » pour obtenir des pistes d'amélioration ciblées.
-            </div>
-          )}
-        </CardContent>
-      </Card>
+        }
+      >
+        {!insights?.metrics?.length ? (
+          <p className="text-sm text-muted-foreground">
+            Publiez du contenu et revenez pour obtenir des recommandations personnalisées.
+          </p>
+        ) : loadingRecommendations ? (
+          <div className="flex items-center justify-center py-6 text-muted-foreground">
+            <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+            Analyse des métriques…
+          </div>
+        ) : recommendationError ? (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Recommandations indisponibles</AlertTitle>
+            <AlertDescription>{recommendationError}</AlertDescription>
+          </Alert>
+        ) : recommendations.length ? (
+          <ul className="space-y-3 text-sm">
+            {recommendations.map((suggestion, index) => (
+              <li
+                key={`${suggestion}-${index}`}
+                className="flex items-start gap-2 rounded-md border border-dashed border-muted-foreground/40 bg-muted/40 p-3"
+              >
+                <Sparkles className="mt-0.5 h-4 w-4 text-primary" />
+                <span>{suggestion}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="text-sm text-muted-foreground">
+            Cliquez sur « Générer » pour obtenir des pistes d'amélioration ciblées.
+          </div>
+        )}
+      </PageSection>
 
       {isEnterprise && (
-        <Card>
-          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <CardTitle className="flex items-center gap-2">
-                <LifeBuoy className="h-5 w-5 text-purple-600" />
-                Support prioritaire
-              </CardTitle>
-              <CardDescription>
-                Accédez rapidement à vos canaux Enterprise et à vos engagements SLA.
-              </CardDescription>
-            </div>
+        <PageSection
+          title="Support prioritaire"
+          description="Vos accès Enterprise centralisés pour contacter l'équipe Postgen AI."
+          actions={
             <Button variant="outline" asChild>
               <a href="/dashboard/support">Ouvrir le centre de support</a>
             </Button>
-          </CardHeader>
-          <CardContent className="grid gap-6 md:grid-cols-3">
-            <div className="space-y-2">
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Mail className="h-4 w-4 text-purple-600" />
-                Email prioritaire
-              </div>
-              <p className="text-sm font-medium">
-                {support?.priorityEmail || "Configurez un email prioritaire dans les paramètres"}
+          }
+          contentClassName="grid gap-6 md:grid-cols-3"
+        >
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Mail className="h-4 w-4 text-purple-600" />
+              Email prioritaire
+            </div>
+            <p className="text-sm font-medium">
+              {support?.priorityEmail || "Configurez un email prioritaire dans les paramètres"}
+            </p>
+            {support?.slackChannel && (
+              <p className="text-xs text-muted-foreground">
+                Canal Slack : {support.slackChannel}
               </p>
-              {support?.slackChannel && (
-                <p className="text-xs text-muted-foreground">
-                  Canal Slack : {support.slackChannel}
-                </p>
-              )}
-            </div>
+            )}
+          </div>
 
-            <div className="space-y-2">
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Phone className="h-4 w-4 text-purple-600" />
-                Ligne directe
-              </div>
-              <p className="text-sm font-medium">
-                {support?.priorityPhone || "Ajoutez une ligne directe pour vos incidents critiques"}
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Phone className="h-4 w-4 text-purple-600" />
+              Ligne directe
+            </div>
+            <p className="text-sm font-medium">
+              {support?.priorityPhone || "Ajoutez une ligne directe pour vos incidents critiques"}
+            </p>
+            {support?.ticketPortalUrl && (
+              <p className="text-xs text-muted-foreground">
+                Portail : {support.ticketPortalUrl.replace(/^https?:\/\//, "")}
               </p>
-              {support?.ticketPortalUrl && (
-                <p className="text-xs text-muted-foreground">
-                  Portail : {support.ticketPortalUrl.replace(/^https?:\/\//, "")}
-                </p>
-              )}
-            </div>
+            )}
+          </div>
 
-            <div className="space-y-2">
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <MessageCircle className="h-4 w-4 text-purple-600" />
-                Engagement SLA
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant="secondary" className="uppercase">
-                  {support?.slaTier || "Non défini"}
-                </Badge>
-                <span className="text-xs text-muted-foreground">
-                  Région prioritaire : {compliance?.preferredDataRegion?.toUpperCase() || "EU"}
-                </span>
-              </div>
-              {support?.slaDocumentUrl ? (
-                <a
-                  href={support.slaDocumentUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-xs text-purple-600 hover:underline"
-                >
-                  Consulter le document SLA
-                </a>
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  Ajoutez votre SLA pour le partager avec les équipes.
-                </p>
-              )}
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <MessageCircle className="h-4 w-4 text-purple-600" />
+              Engagement SLA
             </div>
-          </CardContent>
-        </Card>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="rounded-full bg-purple-100 px-3 py-1 text-xs font-medium text-purple-700">
+                {support?.slaTier || "Non défini"}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                Région prioritaire : {compliance?.preferredDataRegion?.toUpperCase() || "EU"}
+              </span>
+            </div>
+            {support?.slaDocumentUrl ? (
+              <a
+                href={support.slaDocumentUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-purple-600 hover:underline"
+              >
+                Consulter le document SLA
+              </a>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Ajoutez votre SLA pour le partager avec les équipes.
+              </p>
+            )}
+          </div>
+        </PageSection>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/app/generate/page.tsx
+++ b/app/generate/page.tsx
@@ -11,28 +11,23 @@ import {
   RefreshCw,
   Instagram,
   Linkedin,
-  ArrowLeft,
   CheckCircle,
   Search,
   Sparkles,
   Eye,
   Hash,
   ArrowUpLeft,
-  Palette,
-  Image as ImageIcon,
-  Layout,
   FileText,
   Info,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { BrandCarousel } from "@/components/ui/brand-carousel";
 import { BackgroundBeams } from "@/components/ui/background-beams";
 import { Spotlight } from "@/components/ui/spotlight";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Select,
@@ -119,7 +114,6 @@ export default function Generate() {
   const [copiedItem, setCopiedItem] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState("posts");
   const [isVisible, setIsVisible] = useState(false);
-  const [currentSuggestion, setCurrentSuggestion] = useState(0);
   const [selectedPromptId, setSelectedPromptId] = useState<string>("");
 
   const selectedPrompt = useMemo(
@@ -129,10 +123,6 @@ export default function Generate() {
 
   useEffect(() => {
     setIsVisible(true);
-    const interval = setInterval(() => {
-      setCurrentSuggestion((prev) => (prev + 1) % suggestions.length);
-    }, 3000);
-    return () => clearInterval(interval);
   }, []);
 
   useEffect(() => {
@@ -223,10 +213,6 @@ export default function Generate() {
     }
   };
 
-  const selectSuggestion = (suggestion: string) => {
-    setTopic(suggestion);
-  };
-
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     generateContent();
@@ -239,384 +225,355 @@ export default function Generate() {
         <BackgroundBeams />
 
         <div className="relative z-10 container mx-auto px-4 py-12">
-          {/* Header */}
-          <div className={`mb-12 transition-all duration-1000 ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"}`}>
-            <div className="inline-flex items-center space-x-3 mb-6">
-              <h1 className="text-4xl md:text-6xl font-bold bg-clip-text text-transparent bg-gradient-to-b from-neutral-50 to-neutral-400">
-                Générateur de Contenu
+          <div className={`max-w-5xl mx-auto space-y-10 transition-all duration-1000 ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"}`}>
+            <header className="flex flex-col gap-4 text-center">
+              <h1 className="text-4xl md:text-5xl font-semibold bg-clip-text text-transparent bg-gradient-to-b from-neutral-50 to-neutral-400">
+                Générateur de contenu
               </h1>
-            </div>
-
-            <p className="text-xl text-neutral-300 mb-8">
-              Créez du contenu professionnel en quelques secondes
-            </p>
-
-            {currentOrganization && (
-              <div className="inline-flex items-center space-x-3 bg-neutral-950/50 backdrop-blur-xl border border-neutral-800 rounded-full px-6 py-3 mb-8">
-                <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse" />
-                <span className="text-blue-400 font-medium">
+              <p className="text-lg text-neutral-300">
+                Choisissez un brief, indiquez le sujet et laissez Postgen AI livrer des déclinaisons prêtes à publier.
+              </p>
+              {currentOrganization && (
+                <div className="mx-auto inline-flex items-center gap-3 rounded-full border border-neutral-800 bg-neutral-950/60 px-6 py-3 text-sm text-blue-300">
+                  <span className="h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
                   {currentOrganization.name}
-                </span>
-              </div>
-            )}
+                </div>
+              )}
+            </header>
 
-            {/* Generation Form */}
-            <div className="max-w-4xl mx-auto">
+            <div className="grid gap-10 xl:grid-cols-[minmax(0,420px)_minmax(0,1fr)] xl:items-start">
               <form onSubmit={handleSubmit} className="space-y-6">
-                {/* Topic Input */}
-                <div className="relative group">
-                  <div className="absolute inset-0 bg-gradient-to-r from-blue-500/20 to-violet-500/20 rounded-2xl blur-xl opacity-0 group-focus-within:opacity-100 transition-opacity duration-500" />
-                  <div className="relative bg-neutral-950 border border-neutral-800 rounded-2xl p-1.5 group-focus-within:border-blue-500/50 transition-all duration-300">
-                    <div className="flex items-center space-x-4 bg-neutral-900 rounded-xl p-4">
-                      <Search className="w-6 h-6 text-neutral-400 group-focus-within:text-blue-500 transition-colors" />
-                      <Input
-                        type="text"
-                        placeholder="Sur quel sujet voulez-vous créer du contenu ?"
-                        value={topic}
-                        onChange={(e) => setTopic(e.target.value)}
-                        className="flex-1 bg-transparent border-none text-lg placeholder:text-neutral-400 focus-visible:ring-0 focus-visible:ring-offset-0 text-white"
-                      />
-                      <Button
-                        type="submit"
-                        disabled={!topic.trim() || isGenerating}
-                        className="bg-blue-600 hover:bg-blue-700"
-                      >
-                        {isGenerating ? (
-                          <>
-                            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                            Génération...
-                          </>
-                        ) : (
-                          <>
-                            <Sparkles className="w-4 h-4 mr-2" />
-                            Générer
-                          </>
-                        )}
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Suggestions */}
-                <div className="text-center space-y-4">
-                  <p className="text-neutral-500 text-sm">Suggestions :</p>
-                  <div className="flex flex-wrap justify-center gap-2">
-                    {suggestions.map((suggestion, index) => (
-                      <button
-                        key={index}
-                        type="button"
-                        onClick={() => selectSuggestion(suggestion)}
-                        className={`px-4 py-2 text-sm rounded-full border transition-all duration-300 hover:scale-105 ${
-                          index === currentSuggestion
-                            ? "bg-blue-950/50 border-blue-500/50 text-blue-300"
-                            : "bg-neutral-900 border-neutral-700 text-neutral-400 hover:border-neutral-600"
-                        }`}
-                      >
-                        {suggestion}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Prompt Library Selection */}
-                <Card className="bg-neutral-950/50 backdrop-blur-xl border-neutral-800">
-                  <CardHeader className="space-y-1">
-                    <div className="flex items-center justify-between">
-                      <CardTitle className="text-neutral-100 text-lg flex items-center gap-2">
-                        <FileText className="h-5 w-5 text-blue-400" />
-                        Brief de campagne
-                      </CardTitle>
-                      {selectedPrompt && (
-                        <Badge variant="secondary" className="capitalize">
-                          {selectedPrompt.tone}
-                        </Badge>
-                      )}
-                    </div>
+                <Card className="border-neutral-800 bg-neutral-950/60 backdrop-blur">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-neutral-100">
+                      <Search className="h-5 w-5 text-blue-400" />
+                      Sujet de la campagne
+                    </CardTitle>
                     <CardDescription className="text-neutral-400">
-                      Choisissez un template de brief aligné avec les promesses de Postgen AI ou explorez la bibliothèque.
+                      Décrivez votre idée en une phrase pour guider la génération.
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4">
-                    <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-6">
-                      <div className="w-full md:w-2/3">
-                        <Select
-                          value={selectedPromptId || "none"}
-                          onValueChange={(value) =>
-                            setSelectedPromptId(value === "none" ? "" : value)
-                          }
-                        >
-                          <SelectTrigger className="bg-neutral-900/80 border-neutral-700 text-neutral-100">
-                            <SelectValue placeholder="Sélectionnez un brief prêt à l'emploi" />
-                          </SelectTrigger>
-                          <SelectContent className="bg-neutral-900/95 border-neutral-700 text-neutral-100">
-                            <SelectItem value="none">Sans brief prédéfini</SelectItem>
-                            {PROMPT_LIBRARY.map((prompt) => (
-                              <SelectItem key={prompt.id} value={prompt.id}>
-                                {prompt.title}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <div className="flex w-full items-center justify-between gap-3 md:w-1/3">
-                        <Button
+                    <Input
+                      type="text"
+                      placeholder="Ex : Lancement de notre nouveau module d'automatisation"
+                      value={topic}
+                      onChange={(e) => setTopic(e.target.value)}
+                      className="bg-neutral-900/80 border-neutral-800 text-neutral-100 placeholder:text-neutral-500"
+                    />
+                    <div className="flex flex-wrap gap-2 text-xs text-neutral-400">
+                      {suggestions.map((suggestion) => (
+                        <button
+                          key={suggestion}
                           type="button"
-                          variant="outline"
-                          className="flex-1 gap-2 border-neutral-700 text-neutral-200 hover:bg-neutral-800"
-                          onClick={() => setSelectedPromptId("")}
-                          disabled={!selectedPromptId}
+                          onClick={() => setTopic(suggestion)}
+                          className="rounded-full border border-neutral-800 bg-neutral-900/60 px-3 py-1.5 transition hover:border-blue-500 hover:text-blue-300"
                         >
-                          <RefreshCw className="h-4 w-4" />
-                          Réinitialiser
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          className="flex-1 gap-2"
-                          onClick={() => router.push("/dashboard/prompts")}
-                        >
-                          <Sparkles className="h-4 w-4" />
-                          Explorer
-                        </Button>
-                      </div>
+                          {suggestion}
+                        </button>
+                      ))}
+                    </div>
+                    <Button
+                      type="submit"
+                      disabled={!topic.trim() || isGenerating}
+                      className="w-full bg-blue-600 hover:bg-blue-700"
+                    >
+                      {isGenerating ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Génération...
+                        </>
+                      ) : (
+                        <>
+                          <Sparkles className="mr-2 h-4 w-4" />
+                          Générer le contenu
+                        </>
+                      )}
+                    </Button>
+                  </CardContent>
+                </Card>
+
+                <Card className="border-neutral-800 bg-neutral-950/60 backdrop-blur">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-neutral-100">
+                      <FileText className="h-5 w-5 text-blue-400" />
+                      Brief Postgen AI
+                    </CardTitle>
+                    <CardDescription className="text-neutral-400">
+                      Sélectionnez un modèle pour pré-configurer le ton, les audiences et les objectifs.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <Select
+                      value={selectedPromptId || "none"}
+                      onValueChange={(value) => setSelectedPromptId(value === "none" ? "" : value)}
+                    >
+                      <SelectTrigger className="border-neutral-800 bg-neutral-900/80 text-neutral-100">
+                        <SelectValue placeholder="Sélectionnez un brief prêt à l'emploi" />
+                      </SelectTrigger>
+                      <SelectContent className="border-neutral-800 bg-neutral-900 text-neutral-100">
+                        <SelectItem value="none">Sans brief prédéfini</SelectItem>
+                        {PROMPT_LIBRARY.map((prompt) => (
+                          <SelectItem key={prompt.id} value={prompt.id}>
+                            {prompt.title}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <div className="flex gap-3">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="flex-1 border-neutral-800 text-neutral-200 hover:bg-neutral-800"
+                        onClick={() => setSelectedPromptId("")}
+                        disabled={!selectedPromptId}
+                      >
+                        <RefreshCw className="mr-2 h-4 w-4" />
+                        Réinitialiser
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        className="flex-1"
+                        onClick={() => router.push("/dashboard/prompts")}
+                      >
+                        <Sparkles className="mr-2 h-4 w-4" />
+                        Explorer
+                      </Button>
                     </div>
                     {selectedPrompt ? (
-                      <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-4 text-left">
-                        <p className="text-sm text-neutral-200 font-medium">
+                      <div className="space-y-3 rounded-xl border border-neutral-800 bg-neutral-900/60 p-4 text-left">
+                        <p className="text-sm font-medium text-neutral-200">
                           {selectedPrompt.description}
                         </p>
-                        <p className="mt-3 text-sm leading-relaxed text-neutral-400">
+                        <p className="text-sm leading-relaxed text-neutral-400">
                           {selectedPrompt.instructions}
                         </p>
+                        <Badge variant="secondary" className="w-fit capitalize">
+                          Ton : {selectedPrompt.tone}
+                        </Badge>
                       </div>
                     ) : (
-                      <div className="flex items-center gap-3 rounded-xl border border-dashed border-neutral-800 bg-neutral-900/40 p-4 text-sm text-neutral-400">
+                      <div className="flex items-center gap-3 rounded-xl border border-dashed border-neutral-800 bg-neutral-900/50 p-4 text-sm text-neutral-400">
                         <Info className="h-4 w-4" />
-                        Sélectionnez un brief pour pré-remplir les instructions envoyées à l'IA et garder une cohérence éditoriale.
+                        Sélectionnez un brief pour partager des consignes précises avec l'IA.
                       </div>
                     )}
                   </CardContent>
                 </Card>
 
-                {/* Tone Selection */}
-                <Card className="bg-neutral-950/50 backdrop-blur-xl border-neutral-800">
+                <Card className="border-neutral-800 bg-neutral-950/60 backdrop-blur">
                   <CardHeader>
                     <CardTitle className="text-neutral-100">Ton de communication</CardTitle>
+                    <CardDescription className="text-neutral-400">
+                      Choisissez l'intonation à appliquer aux différentes déclinaisons.
+                    </CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <RadioGroup value={tone} onValueChange={setTone} className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    <RadioGroup value={tone} onValueChange={setTone} className="grid grid-cols-2 gap-3">
                       {toneOptions.map((option) => (
-                        <div key={option.value} className="relative">
-                          <div className="flex items-center space-x-4 p-4 rounded-xl border border-neutral-700 hover:border-neutral-600 transition-all cursor-pointer">
-                            <RadioGroupItem
-                              value={option.value}
-                              id={option.value}
-                              className="border-neutral-400 text-blue-600"
-                            />
-                            <div className="text-xl">{option.icon}</div>
-                            <div className="flex-1">
-                              <Label
-                                htmlFor={option.value}
-                                className="text-neutral-100 font-medium cursor-pointer"
-                              >
-                                {option.label}
-                              </Label>
-                              <p className="text-neutral-500 text-sm mt-0.5">
-                                {option.description}
-                              </p>
-                            </div>
+                        <label
+                          key={option.value}
+                          htmlFor={option.value}
+                          className="flex cursor-pointer items-center gap-3 rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 transition hover:border-blue-500"
+                        >
+                          <RadioGroupItem
+                            value={option.value}
+                            id={option.value}
+                            className="border-neutral-400 text-blue-500"
+                          />
+                          <div className="text-left">
+                            <p className="text-sm font-medium text-neutral-100">
+                              {option.icon} {option.label}
+                            </p>
+                            <p className="text-xs text-neutral-400">{option.description}</p>
                           </div>
-                        </div>
+                        </label>
                       ))}
                     </RadioGroup>
                   </CardContent>
                 </Card>
               </form>
-            </div>
-          </div>
 
-          {/* Generated Content */}
-          {isGenerating && (
-            <div className="flex flex-col items-center justify-center py-32">
-              <div className="relative mb-8">
-                <div className="w-20 h-20 border-4 border-blue-500/20 rounded-full animate-spin">
-                  <div className="absolute top-0 left-0 w-4 h-4 bg-blue-500 rounded-full" />
+              <div className="space-y-6">
+                <Card className="border-neutral-800 bg-neutral-950/60 backdrop-blur">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-neutral-100">
+                      <Eye className="h-5 w-5 text-blue-400" />
+                      Aperçu en direct
+                    </CardTitle>
+                    <CardDescription className="text-neutral-400">
+                      Consultez toutes les déclinaisons générées et copiez-les en un clic.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    {isGenerating ? (
+                      <div className="flex flex-col items-center gap-4 py-12 text-neutral-300">
+                        <Loader2 className="h-6 w-6 animate-spin text-blue-400" />
+                        <p>Génération du contenu en cours…</p>
+                      </div>
+                    ) : generatedContent ? (
+                      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+                        <TabsList className="grid w-full grid-cols-3 gap-1 rounded-xl border border-neutral-800 bg-neutral-900/60 p-1">
+                          <TabsTrigger value="posts" className="rounded-lg data-[state=active]:bg-neutral-800 data-[state=active]:text-neutral-100">
+                            Publications
+                          </TabsTrigger>
+                          <TabsTrigger value="carousel" className="rounded-lg data-[state=active]:bg-neutral-800 data-[state=active]:text-neutral-100">
+                            Carrousel
+                          </TabsTrigger>
+                          <TabsTrigger value="hashtags" className="rounded-lg data-[state=active]:bg-neutral-800 data-[state=active]:text-neutral-100">
+                            Hashtags
+                          </TabsTrigger>
+                        </TabsList>
+
+                        <TabsContent value="posts" className="space-y-6 pt-6">
+                          <div className="grid gap-6 lg:grid-cols-2">
+                            <Card className="border-neutral-800 bg-neutral-900/60">
+                              <CardHeader>
+                                <CardTitle className="flex items-center gap-2 text-neutral-100">
+                                  <Linkedin className="h-5 w-5 text-blue-400" />
+                                  LinkedIn
+                                </CardTitle>
+                              </CardHeader>
+                              <CardContent className="space-y-4">
+                                <div className="max-h-80 overflow-y-auto rounded-xl border border-neutral-800 bg-neutral-950/70 p-5 text-sm text-neutral-200">
+                                  {generatedContent.linkedinPost}
+                                </div>
+                                <Button
+                                  onClick={() => copyToClipboard(generatedContent.linkedinPost, "linkedin")}
+                                  className="w-full"
+                                >
+                                  {copiedItem === "linkedin" ? (
+                                    <>
+                                      <CheckCircle className="mr-2 h-4 w-4" />
+                                      Copié !
+                                    </>
+                                  ) : (
+                                    <>
+                                      <Copy className="mr-2 h-4 w-4" />
+                                      Copier le post
+                                    </>
+                                  )}
+                                </Button>
+                              </CardContent>
+                            </Card>
+
+                            <Card className="border-neutral-800 bg-neutral-900/60">
+                              <CardHeader>
+                                <CardTitle className="flex items-center gap-2 text-neutral-100">
+                                  <Instagram className="h-5 w-5 text-pink-400" />
+                                  Instagram
+                                </CardTitle>
+                              </CardHeader>
+                              <CardContent className="space-y-4">
+                                <div className="max-h-80 overflow-y-auto rounded-xl border border-neutral-800 bg-neutral-950/70 p-5 text-sm text-neutral-200">
+                                  {generatedContent.instagramPost}
+                                </div>
+                                <Button
+                                  onClick={() => copyToClipboard(generatedContent.instagramPost, "instagram")}
+                                  className="w-full"
+                                >
+                                  {copiedItem === "instagram" ? (
+                                    <>
+                                      <CheckCircle className="mr-2 h-4 w-4" />
+                                      Copié !
+                                    </>
+                                  ) : (
+                                    <>
+                                      <Copy className="mr-2 h-4 w-4" />
+                                      Copier le post
+                                    </>
+                                  )}
+                                </Button>
+                              </CardContent>
+                            </Card>
+                          </div>
+                        </TabsContent>
+
+                        <TabsContent value="carousel" className="pt-6">
+                          <BrandCarousel
+                            slides={generatedContent.carousel}
+                            branding={{
+                              topic,
+                              logo: null,
+                              primaryColor: "#0080FF",
+                              secondaryColor: "#0066CC",
+                              tone,
+                            }}
+                            autoPlay
+                            autoPlayInterval={5000}
+                          />
+                        </TabsContent>
+
+                        <TabsContent value="hashtags" className="space-y-4 pt-6">
+                          <div className="flex flex-wrap gap-3">
+                            {generatedContent.hashtags.map((hashtag, index) => (
+                              <button
+                                key={index}
+                                onClick={() => copyToClipboard(hashtag, `hashtag-${index}`)}
+                                className="rounded-full border border-neutral-800 bg-neutral-900/60 px-3 py-2 text-sm text-blue-300 transition hover:border-blue-500"
+                              >
+                                {hashtag}
+                              </button>
+                            ))}
+                          </div>
+                          <Button
+                            onClick={() => copyToClipboard(generatedContent.hashtags.join(" "), "hashtags")}
+                            className="w-full"
+                          >
+                            {copiedItem === "hashtags" ? (
+                              <>
+                                <CheckCircle className="mr-2 h-4 w-4" />
+                                Copié !
+                              </>
+                            ) : (
+                              <>
+                                <Copy className="mr-2 h-4 w-4" />
+                                Copier tous les hashtags
+                              </>
+                            )}
+                          </Button>
+                        </TabsContent>
+                      </Tabs>
+                    ) : (
+                      <div className="space-y-4 rounded-xl border border-dashed border-neutral-800 bg-neutral-900/40 p-8 text-center text-neutral-400">
+                        <Sparkles className="mx-auto h-6 w-6 text-blue-400" />
+                        <p>
+                          Lancez une génération pour visualiser les déclinaisons LinkedIn, Instagram et vos hashtags optimisés.
+                        </p>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+
+                <div className="flex flex-wrap justify-between gap-4">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => router.push("/dashboard")}
+                    className="border-neutral-800 bg-black text-neutral-300 hover:text-white"
+                  >
+                    <ArrowUpLeft className="mr-2 h-4 w-4" />
+                    Retour au dashboard
+                  </Button>
+                  {generatedContent && (
+                    <Button onClick={generateContent} disabled={isGenerating || !topic.trim()}>
+                      {isGenerating ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Génération...
+                        </>
+                      ) : (
+                        <>
+                          <RefreshCw className="mr-2 h-4 w-4" />
+                          Régénérer
+                        </>
+                      )}
+                    </Button>
+                  )}
                 </div>
               </div>
-              <h3 className="text-2xl font-semibold text-neutral-100 mb-4">
-                Génération en cours...
-              </h3>
-              <p className="text-neutral-400 text-lg">
-                L'IA crée votre contenu personnalisé
-              </p>
             </div>
-          )}
-
-          {generatedContent && !isGenerating && (
-            <div className="max-w-7xl mx-auto">
-              <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-                <TabsList className="grid w-full grid-cols-3 bg-neutral-950/50 backdrop-blur-xl border border-neutral-800 rounded-2xl p-1.5 mb-8">
-                  <TabsTrigger value="posts" className="data-[state=active]:bg-neutral-800 data-[state=active]:text-neutral-100 rounded-xl">
-                    <Eye className="w-4 h-4 mr-2" />
-                    Publications
-                  </TabsTrigger>
-                  <TabsTrigger value="carousel" className="data-[state=active]:bg-neutral-800 data-[state=active]:text-neutral-100 rounded-xl">
-                    <Sparkles className="w-4 h-4 mr-2" />
-                    Carrousel
-                  </TabsTrigger>
-                  <TabsTrigger value="hashtags" className="data-[state=active]:bg-neutral-800 data-[state=active]:text-neutral-100 rounded-xl">
-                    <Hash className="w-4 h-4 mr-2" />
-                    Hashtags
-                  </TabsTrigger>
-                </TabsList>
-
-                <TabsContent value="posts" className="space-y-8">
-                  <div className="grid lg:grid-cols-2 gap-8">
-                    {/* LinkedIn Post */}
-                    <Card className="bg-neutral-950/50 backdrop-blur-xl border-neutral-800">
-                      <CardHeader>
-                        <CardTitle className="text-neutral-100 flex items-center space-x-3">
-                          <Linkedin className="w-5 h-5 text-blue-400" />
-                          <span>LinkedIn</span>
-                        </CardTitle>
-                      </CardHeader>
-                      <CardContent className="space-y-6">
-                        <div className="bg-neutral-900/50 p-6 rounded-2xl border border-neutral-800 max-h-96 overflow-y-auto">
-                          <pre className="text-neutral-300 whitespace-pre-wrap font-sans text-sm leading-relaxed">
-                            {generatedContent.linkedinPost}
-                          </pre>
-                        </div>
-                        <Button
-                          onClick={() => copyToClipboard(generatedContent.linkedinPost, "linkedin")}
-                          className="w-full"
-                        >
-                          {copiedItem === "linkedin" ? (
-                            <>
-                              <CheckCircle className="w-4 h-4 mr-2" />
-                              Copié !
-                            </>
-                          ) : (
-                            <>
-                              <Copy className="w-4 h-4 mr-2" />
-                              Copier
-                            </>
-                          )}
-                        </Button>
-                      </CardContent>
-                    </Card>
-
-                    {/* Instagram Post */}
-                    <Card className="bg-neutral-950/50 backdrop-blur-xl border-neutral-800">
-                      <CardHeader>
-                        <CardTitle className="text-neutral-100 flex items-center space-x-3">
-                          <Instagram className="w-5 h-5 text-pink-400" />
-                          <span>Instagram</span>
-                        </CardTitle>
-                      </CardHeader>
-                      <CardContent className="space-y-6">
-                        <div className="bg-neutral-900/50 p-6 rounded-2xl border border-neutral-800 max-h-96 overflow-y-auto">
-                          <pre className="text-neutral-300 whitespace-pre-wrap font-sans text-sm leading-relaxed">
-                            {generatedContent.instagramPost}
-                          </pre>
-                        </div>
-                        <Button
-                          onClick={() => copyToClipboard(generatedContent.instagramPost, "instagram")}
-                          className="w-full"
-                        >
-                          {copiedItem === "instagram" ? (
-                            <>
-                              <CheckCircle className="w-4 h-4 mr-2" />
-                              Copié !
-                            </>
-                          ) : (
-                            <>
-                              <Copy className="w-4 h-4 mr-2" />
-                              Copier
-                            </>
-                          )}
-                        </Button>
-                      </CardContent>
-                    </Card>
-                  </div>
-                </TabsContent>
-
-                <TabsContent value="carousel" className="space-y-8">
-                  <BrandCarousel
-                    slides={generatedContent.carousel}
-                    branding={{
-                      topic,
-                      logo: null,
-                      primaryColor: "#0080FF",
-                      secondaryColor: "#0066CC",
-                      tone,
-                    }}
-                    autoPlay={true}
-                    autoPlayInterval={5000}
-                  />
-                </TabsContent>
-
-                <TabsContent value="hashtags" className="space-y-8">
-                  <Card className="bg-neutral-950/50 backdrop-blur-xl border-neutral-800">
-                    <CardHeader>
-                      <CardTitle className="text-neutral-100">Hashtags optimisés</CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-6">
-                      <div className="flex flex-wrap gap-3">
-                        {generatedContent.hashtags.map((hashtag, index) => (
-                          <button
-                            key={index}
-                            onClick={() => copyToClipboard(hashtag, `hashtag-${index}`)}
-                            className="px-4 py-2 bg-neutral-900/50 border border-neutral-800 rounded-xl hover:border-neutral-700 transition-all"
-                          >
-                            <span className="text-blue-400 font-medium">{hashtag}</span>
-                          </button>
-                        ))}
-                      </div>
-                      <Button
-                        onClick={() => copyToClipboard(generatedContent.hashtags.join(" "), "hashtags")}
-                        className="w-full"
-                      >
-                        {copiedItem === "hashtags" ? (
-                          <>
-                            <CheckCircle className="w-4 h-4 mr-2" />
-                            Copié !
-                          </>
-                        ) : (
-                          <>
-                            <Copy className="w-4 h-4 mr-2" />
-                            Copier tous les hashtags
-                          </>
-                        )}
-                      </Button>
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-              </Tabs>
-            </div>
-          )}
-
-          {/* Navigation */}
-          <div className="flex justify-between items-center mt-16 max-w-7xl mx-auto">
-            <Button variant="outline" onClick={() => router.push("/dashboard")} className="border-neutral-700 bg-black text-neutral-300">
-              <ArrowUpLeft className="w-4 h-4 mr-2" />
-              Retour au dashboard
-            </Button>
-
-            {generatedContent && (
-              <Button onClick={generateContent} disabled={isGenerating || !topic.trim()}>
-                {isGenerating ? (
-                  <>
-                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                    Génération...
-                  </>
-                ) : (
-                  <>
-                    <RefreshCw className="w-4 h-4 mr-2" />
-                    Régénérer
-                  </>
-                )}
-              </Button>
-            )}
           </div>
         </div>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,6 +61,39 @@ const workflow = [
   },
 ];
 
+const heroStats = [
+  {
+    label: "Temps moyen gagné",
+    value: "6h / semaine",
+    description: "grâce à l'automatisation des briefs et validations.",
+  },
+  {
+    label: "Satisfaction des équipes",
+    value: "94%",
+    description: "des utilisateurs constatent une meilleure cohérence éditoriale.",
+  },
+  {
+    label: "Vitesse de publication",
+    value: "x4",
+    description: "de posts déployés sur vos réseaux préférés.",
+  },
+];
+
+const reliabilityHighlights = [
+  {
+    icon: ShieldCheck,
+    text: "Données hébergées en Europe et chiffrées de bout en bout.",
+  },
+  {
+    icon: Layers,
+    text: "Intégration native avec vos outils : Notion, HubSpot, Slack, Zapier.",
+  },
+  {
+    icon: Clock3,
+    text: "Support en français disponible en moins de 5 minutes ouvrées.",
+  },
+];
+
 export default function Home() {
   const { user, loading } = useAuth();
   const router = useRouter();
@@ -145,45 +178,19 @@ export default function Home() {
                 </Button>
               </div>
               <div className="mt-12 grid gap-6 md:grid-cols-3">
-                <Card className="bg-white/5 border-white/10 text-white">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-sm font-medium text-slate-200">
-                      Temps moyen gagné
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-3xl font-semibold">6h / semaine</p>
-                    <p className="text-sm text-slate-300">
-                      grâce à l'automatisation des briefs et validations.
-                    </p>
-                  </CardContent>
-                </Card>
-                <Card className="bg-white/5 border-white/10 text-white">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-sm font-medium text-slate-200">
-                      Satisfaction des équipes
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-3xl font-semibold">94%</p>
-                    <p className="text-sm text-slate-300">
-                      des utilisateurs constatent une meilleure cohérence éditoriale.
-                    </p>
-                  </CardContent>
-                </Card>
-                <Card className="bg-white/5 border-white/10 text-white">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-sm font-medium text-slate-200">
-                      Vitesse de publication
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-3xl font-semibold">x4</p>
-                    <p className="text-sm text-slate-300">
-                      de posts déployés sur vos réseaux préférés.
-                    </p>
-                  </CardContent>
-                </Card>
+                {heroStats.map((stat) => (
+                  <Card key={stat.label} className="bg-white/5 border-white/10 text-white">
+                    <CardHeader className="pb-2">
+                      <CardTitle className="text-sm font-medium text-slate-200">
+                        {stat.label}
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <p className="text-3xl font-semibold">{stat.value}</p>
+                      <p className="text-sm text-slate-300">{stat.description}</p>
+                    </CardContent>
+                  </Card>
+                ))}
               </div>
             </div>
           </div>
@@ -274,18 +281,12 @@ export default function Home() {
                 Clara, Head of Content chez NovaTech, pilote une équipe de 6 créateurs. Avec Postgen AI, elle collabore sur un même calendrier éditorial, valide les contenus en quelques clics et mesure l'impact sans multiplier les outils.
               </p>
               <div className="mt-8 flex flex-col gap-3 text-sm text-muted-foreground">
-                <div className="flex items-center gap-3">
-                  <ShieldCheck className="h-5 w-5 text-slate-700" />
-                  Données hébergées en Europe et chiffrées de bout en bout.
-                </div>
-                <div className="flex items-center gap-3">
-                  <Layers className="h-5 w-5 text-slate-700" />
-                  Intégration native avec vos outils : Notion, HubSpot, Slack, Zapier.
-                </div>
-                <div className="flex items-center gap-3">
-                  <Clock3 className="h-5 w-5 text-slate-700" />
-                  Support en français disponible en moins de 5 minutes ouvrées.
-                </div>
+                {reliabilityHighlights.map((item) => (
+                  <div key={item.text} className="flex items-center gap-3">
+                    <item.icon className="h-5 w-5 text-slate-700" />
+                    {item.text}
+                  </div>
+                ))}
               </div>
             </div>
             <Card className="border-primary/20 shadow-lg shadow-slate-900/5">

--- a/components/ui/page-shell.tsx
+++ b/components/ui/page-shell.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+interface PageShellProps {
+  children: React.ReactNode;
+  className?: string;
+  padded?: boolean;
+}
+
+export function PageShell({
+  children,
+  className,
+  padded = true,
+}: PageShellProps) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-8", // ensure vertical rhythm
+        padded && "pb-10",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface PageHeaderProps {
+  title: string;
+  description?: string;
+  eyebrow?: string;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export function PageHeader({
+  title,
+  description,
+  eyebrow,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div className={cn("flex flex-col gap-4", className)}>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          {eyebrow && (
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {eyebrow}
+            </p>
+          )}
+          <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">{title}</h1>
+          {description && (
+            <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
+              {description}
+            </p>
+          )}
+        </div>
+        {actions ? (
+          <div className="flex shrink-0 items-center gap-2">{actions}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface PageSectionProps {
+  title?: string;
+  description?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  contentClassName?: string;
+}
+
+export function PageSection({
+  title,
+  description,
+  actions,
+  children,
+  className,
+  contentClassName,
+}: PageSectionProps) {
+  return (
+    <section className={cn("flex flex-col gap-6", className)}>
+      {(title || description || actions) && (
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            {title && <h2 className="text-lg font-semibold sm:text-xl">{title}</h2>}
+            {description && (
+              <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
+                {description}
+              </p>
+            )}
+          </div>
+          {actions ? (
+            <div className="flex shrink-0 items-center gap-2">{actions}</div>
+          ) : null}
+        </header>
+      )}
+      <div className={cn("space-y-6", contentClassName)}>{children}</div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a reusable page shell with header and section helpers to align layouts
- simplify the dashboard into focused sections with clearer actions and enterprise support summary
- reorganize the generation and branding flows into guided two-column experiences while keeping existing styling
- map landing hero stats and trust highlights from structured data for easier maintenance

## Testing
- `pnpm lint` *(fails: ESLint is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d794b540c08323b6ea814acecf166f