### PR TITLE
Add billing and account settings sections to dashboard

### DIFF
--- a/app/dashboard/settings/account/page.tsx
+++ b/app/dashboard/settings/account/page.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import AuthPage from "@/app/auth/page";
+import { AuthGuard } from "@/components/auth/AuthGuard";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { useAuth } from "@/contexts/AuthContext";
+
+const LANGUAGES = [
+  { value: "fr", label: "Français" },
+  { value: "en", label: "Anglais" },
+  { value: "es", label: "Espagnol" },
+];
+
+const TIMEZONES = [
+  { value: "Europe/Paris", label: "Europe/Paris (UTC+1)" },
+  { value: "Europe/Brussels", label: "Europe/Bruxelles (UTC+1)" },
+  { value: "America/Montreal", label: "Amérique/Montréal (UTC-5)" },
+];
+
+export default function AccountSettingsPage() {
+  const { user, updateUserProfile } = useAuth();
+  const [displayName, setDisplayName] = useState("");
+  const [language, setLanguage] = useState("fr");
+  const [timezone, setTimezone] = useState("Europe/Paris");
+  const [savingProfile, setSavingProfile] = useState(false);
+  const [profileSuccess, setProfileSuccess] = useState<string | null>(null);
+  const [profileError, setProfileError] = useState<string | null>(null);
+
+  const defaultCommunicationPrefs = useMemo(
+    () => ({
+      productUpdates: true,
+      weeklySummary: true,
+      securityAlerts: true,
+    }),
+    [],
+  );
+
+  const [communicationPrefs, setCommunicationPrefs] = useState(defaultCommunicationPrefs);
+  const [savingPrefs, setSavingPrefs] = useState(false);
+  const [prefsSuccess, setPrefsSuccess] = useState<string | null>(null);
+  const [prefsError, setPrefsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+
+    setDisplayName(user.name ?? "");
+    setLanguage(user.language ?? "fr");
+    setTimezone(user.timezone ?? "Europe/Paris");
+    setCommunicationPrefs({
+      productUpdates: user.communicationPreferences?.productUpdates ?? true,
+      weeklySummary: user.communicationPreferences?.weeklySummary ?? true,
+      securityAlerts: user.communicationPreferences?.securityAlerts ?? true,
+    });
+  }, [user]);
+
+  if (!user) {
+    return (
+      <AuthGuard fallback={<AuthPage />}>
+        <div className="flex min-h-[60vh] items-center justify-center p-6 text-muted-foreground">
+          Chargement du compte...
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  const handleSaveProfile = async () => {
+    setSavingProfile(true);
+    setProfileSuccess(null);
+    setProfileError(null);
+
+    try {
+      await updateUserProfile({
+        name: displayName,
+        language,
+        timezone,
+      });
+      setProfileSuccess("Profil mis à jour avec succès.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Impossible d'enregistrer les modifications.";
+      setProfileError(message);
+    } finally {
+      setSavingProfile(false);
+    }
+  };
+
+  const handleSaveCommunication = async () => {
+    setSavingPrefs(true);
+    setPrefsSuccess(null);
+    setPrefsError(null);
+
+    try {
+      await updateUserProfile({
+        communicationPreferences: communicationPrefs,
+      });
+      setPrefsSuccess("Préférences de communication enregistrées.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Impossible d'enregistrer les préférences.";
+      setPrefsError(message);
+    } finally {
+      setSavingPrefs(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold">Paramètres du compte</h1>
+        <p className="text-sm text-muted-foreground">
+          Actualisez vos informations personnelles et choisissez comment Postgen AI communique avec vous.
+        </p>
+      </div>
+      <Separator />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Informations personnelles</CardTitle>
+          <CardDescription>
+            Vos informations sont utilisées dans les notifications et les actions collaboratives.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="display-name">Nom affiché</Label>
+              <Input
+                id="display-name"
+                value={displayName}
+                onChange={(event) => setDisplayName(event.target.value)}
+                placeholder="Votre nom complet"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Adresse email</Label>
+              <Input id="email" value={user.email} disabled />
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Langue de l'interface</Label>
+              <Select value={language} onValueChange={setLanguage}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Sélectionnez une langue" />
+                </SelectTrigger>
+                <SelectContent>
+                  {LANGUAGES.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Fuseau horaire</Label>
+              <Select value={timezone} onValueChange={setTimezone}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Sélectionnez un fuseau horaire" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TIMEZONES.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-sm text-muted-foreground">
+            Vos préférences seront synchronisées sur tous vos espaces de travail.
+          </div>
+          <div className="space-y-1 text-right">
+            <Button onClick={handleSaveProfile} disabled={savingProfile}>
+              {savingProfile ? "Enregistrement..." : "Enregistrer"}
+            </Button>
+            {profileSuccess && (
+              <p className="text-xs text-green-600">{profileSuccess}</p>
+            )}
+            {profileError && (
+              <p className="text-xs text-destructive">{profileError}</p>
+            )}
+          </div>
+        </CardFooter>
+      </Card>
+
+      <Card id="notifications">
+        <CardHeader>
+          <CardTitle>Notifications & communication</CardTitle>
+          <CardDescription>
+            Choisissez comment nous vous tenons informé des nouveautés et des activités importantes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+            <div>
+              <p className="font-medium">Alertes de sécurité</p>
+              <p className="text-sm text-muted-foreground">
+                Recevez immédiatement un email en cas d'activité suspecte ou de mise à jour critique.
+              </p>
+            </div>
+            <Switch
+              checked={communicationPrefs.securityAlerts}
+              onCheckedChange={(checked) =>
+                setCommunicationPrefs((previous) => ({
+                  ...previous,
+                  securityAlerts: checked,
+                }))
+              }
+            />
+          </div>
+          <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+            <div>
+              <p className="font-medium">Résumé hebdomadaire</p>
+              <p className="text-sm text-muted-foreground">
+                Recevez chaque lundi un résumé des performances et des actions à venir.
+              </p>
+            </div>
+            <Switch
+              checked={communicationPrefs.weeklySummary}
+              onCheckedChange={(checked) =>
+                setCommunicationPrefs((previous) => ({
+                  ...previous,
+                  weeklySummary: checked,
+                }))
+              }
+            />
+          </div>
+          <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+            <div>
+              <div className="flex items-center gap-2">
+                <p className="font-medium">Mises à jour produit</p>
+                <Badge variant="secondary">Recommandé</Badge>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Soyez informé des nouvelles fonctionnalités, webinaires et bonnes pratiques.
+              </p>
+            </div>
+            <Switch
+              checked={communicationPrefs.productUpdates}
+              onCheckedChange={(checked) =>
+                setCommunicationPrefs((previous) => ({
+                  ...previous,
+                  productUpdates: checked,
+                }))
+              }
+            />
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-sm text-muted-foreground">
+            Vous pourrez vous désinscrire à tout moment depuis chaque email reçu.
+          </div>
+          <div className="space-y-1 text-right">
+            <Button onClick={handleSaveCommunication} disabled={savingPrefs}>
+              {savingPrefs ? "Enregistrement..." : "Enregistrer les préférences"}
+            </Button>
+            {prefsSuccess && <p className="text-xs text-green-600">{prefsSuccess}</p>}
+            {prefsError && <p className="text-xs text-destructive">{prefsError}</p>}
+          </div>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/app/dashboard/settings/billing/page.tsx
+++ b/app/dashboard/settings/billing/page.tsx
@@ -1,0 +1,568 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+import AuthPage from "@/app/auth/page";
+import { AuthGuard } from "@/components/auth/AuthGuard";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useAuth } from "@/contexts/AuthContext";
+import { type BillingSettings, type InvoiceRecord, type PaymentMethodDetails } from "@/lib/auth";
+import { PLAN_LABELS, type PlanId, PRICING_PLANS } from "@/lib/plans";
+
+const DEFAULT_INVOICES: InvoiceRecord[] = [
+  {
+    id: "INV-2024-03",
+    label: "Mars 2024",
+    amount: 29,
+    currency: "EUR",
+    status: "paid",
+    issuedAt: new Date("2024-03-01").toISOString(),
+    downloadUrl: "#",
+  },
+  {
+    id: "INV-2024-02",
+    label: "Février 2024",
+    amount: 29,
+    currency: "EUR",
+    status: "paid",
+    issuedAt: new Date("2024-02-01").toISOString(),
+    downloadUrl: "#",
+  },
+  {
+    id: "INV-2024-01",
+    label: "Janvier 2024",
+    amount: 0,
+    currency: "EUR",
+    status: "void",
+    issuedAt: new Date("2024-01-01").toISOString(),
+    downloadUrl: "#",
+  },
+];
+
+const STATUS_LABELS: Record<InvoiceRecord["status"], string> = {
+  paid: "Payée",
+  due: "À régler",
+  failed: "Échouée",
+  void: "Annulée",
+};
+
+const formatter = new Intl.NumberFormat("fr-FR", {
+  style: "currency",
+  currency: "EUR",
+});
+
+export default function BillingSettingsPage() {
+  const { currentOrganization, updateCurrentOrganization } = useAuth();
+  const [billingEmail, setBillingEmail] = useState("");
+  const [companyName, setCompanyName] = useState("");
+  const [vatNumber, setVatNumber] = useState("");
+  const [addressLine1, setAddressLine1] = useState("");
+  const [addressLine2, setAddressLine2] = useState("");
+  const [postalCode, setPostalCode] = useState("");
+  const [city, setCity] = useState("");
+  const [country, setCountry] = useState("");
+  const [purchaseOrder, setPurchaseOrder] = useState("");
+  const [cardBrand, setCardBrand] = useState("");
+  const [cardLast4, setCardLast4] = useState("");
+  const [cardExpMonth, setCardExpMonth] = useState("01");
+  const [cardExpYear, setCardExpYear] = useState("2024");
+  const [billingSuccess, setBillingSuccess] = useState<string | null>(null);
+  const [billingError, setBillingError] = useState<string | null>(null);
+  const [paymentSuccess, setPaymentSuccess] = useState<string | null>(null);
+  const [paymentError, setPaymentError] = useState<string | null>(null);
+  const [planSuccess, setPlanSuccess] = useState<string | null>(null);
+  const [planError, setPlanError] = useState<string | null>(null);
+  const [savingBilling, setSavingBilling] = useState(false);
+  const [savingPayment, setSavingPayment] = useState(false);
+  const [updatingPlan, setUpdatingPlan] = useState<PlanId | null>(null);
+
+  useEffect(() => {
+    if (!currentOrganization) {
+      return;
+    }
+
+    const billing = currentOrganization.billing ?? {};
+    setBillingEmail(billing.billingEmail ?? "");
+    setCompanyName(billing.contact?.companyName ?? currentOrganization.name ?? "");
+    setVatNumber(billing.contact?.vatNumber ?? "");
+    setAddressLine1(billing.contact?.addressLine1 ?? "");
+    setAddressLine2(billing.contact?.addressLine2 ?? "");
+    setPostalCode(billing.contact?.postalCode ?? "");
+    setCity(billing.contact?.city ?? "");
+    setCountry(billing.contact?.country ?? "");
+    setPurchaseOrder(billing.contact?.purchaseOrder ?? "");
+
+    if (billing.paymentMethod) {
+      setCardBrand(billing.paymentMethod.brand);
+      setCardLast4(billing.paymentMethod.last4);
+      setCardExpMonth(billing.paymentMethod.expMonth.toString().padStart(2, "0"));
+      setCardExpYear(billing.paymentMethod.expYear.toString());
+    }
+  }, [currentOrganization]);
+
+  const invoices = useMemo(() => {
+    if (!currentOrganization?.billing?.invoices || currentOrganization.billing.invoices.length === 0) {
+      return DEFAULT_INVOICES;
+    }
+
+    return currentOrganization.billing.invoices;
+  }, [currentOrganization]);
+
+  if (!currentOrganization) {
+    return (
+      <AuthGuard fallback={<AuthPage />}>
+        <div className="flex min-h-[60vh] items-center justify-center p-6 text-muted-foreground">
+          Chargement des paramètres de facturation...
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  const handleSaveBilling = async () => {
+    setSavingBilling(true);
+    setBillingSuccess(null);
+    setBillingError(null);
+
+    try {
+      const nextBilling: BillingSettings = {
+        ...currentOrganization.billing,
+        billingEmail,
+        contact: {
+          ...currentOrganization.billing?.contact,
+          companyName,
+          vatNumber,
+          addressLine1,
+          addressLine2,
+          postalCode,
+          city,
+          country,
+          purchaseOrder,
+        },
+      };
+      await updateCurrentOrganization({ billing: nextBilling });
+      setBillingSuccess("Informations de facturation mises à jour.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Impossible d'enregistrer les informations.";
+      setBillingError(message);
+    } finally {
+      setSavingBilling(false);
+    }
+  };
+
+  const handleSavePaymentMethod = async () => {
+    setSavingPayment(true);
+    setPaymentSuccess(null);
+    setPaymentError(null);
+
+    try {
+      const paymentMethod: PaymentMethodDetails = {
+        brand: cardBrand,
+        last4: cardLast4,
+        expMonth: Number.parseInt(cardExpMonth, 10),
+        expYear: Number.parseInt(cardExpYear, 10),
+        isDefault: true,
+      };
+
+      const nextBilling: BillingSettings = {
+        ...currentOrganization.billing,
+        billingEmail,
+        contact: {
+          ...currentOrganization.billing?.contact,
+          companyName,
+        },
+        paymentMethod,
+      };
+
+      await updateCurrentOrganization({ billing: nextBilling });
+      setPaymentSuccess("Moyen de paiement enregistré.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Impossible d'enregistrer le moyen de paiement.";
+      setPaymentError(message);
+    } finally {
+      setSavingPayment(false);
+    }
+  };
+
+  const handleSelectPlan = async (planId: PlanId) => {
+    setUpdatingPlan(planId);
+    setPlanSuccess(null);
+    setPlanError(null);
+
+    try {
+      const renewal = new Date();
+      renewal.setMonth(renewal.getMonth() + 1);
+
+      const nextBilling: BillingSettings = {
+        ...currentOrganization.billing,
+        planRenewalDate: renewal.toISOString(),
+      };
+
+      await updateCurrentOrganization({ plan: planId, billing: nextBilling });
+      setPlanSuccess(`Le plan ${PLAN_LABELS[planId]} est maintenant actif.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "La mise à jour du plan a échoué.";
+      setPlanError(message);
+    } finally {
+      setUpdatingPlan(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold">Abonnement & facturation</h1>
+        <p className="text-sm text-muted-foreground">
+          Consultez votre plan actuel, gérez vos informations de facturation et accédez à votre historique.
+        </p>
+      </div>
+      <Separator />
+
+      <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+        <div className="flex flex-col gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Informations de facturation</CardTitle>
+              <CardDescription>
+                Les coordonnées figurant sur vos factures et documents comptables.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="billing-email">Email de facturation</Label>
+                  <Input
+                    id="billing-email"
+                    type="email"
+                    value={billingEmail}
+                    placeholder="facturation@exemple.com"
+                    onChange={(event) => setBillingEmail(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="company-name">Raison sociale</Label>
+                  <Input
+                    id="company-name"
+                    value={companyName}
+                    placeholder="Nom de l'entreprise"
+                    onChange={(event) => setCompanyName(event.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="vat-number">Numéro de TVA intracom.</Label>
+                  <Input
+                    id="vat-number"
+                    value={vatNumber}
+                    placeholder="FRXX999999999"
+                    onChange={(event) => setVatNumber(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="purchase-order">Numéro de bon de commande</Label>
+                  <Input
+                    id="purchase-order"
+                    value={purchaseOrder}
+                    placeholder="PO-2024-001"
+                    onChange={(event) => setPurchaseOrder(event.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="address-line1">Adresse</Label>
+                  <Input
+                    id="address-line1"
+                    value={addressLine1}
+                    placeholder="12 rue des Lilas"
+                    onChange={(event) => setAddressLine1(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="address-line2">Complément</Label>
+                  <Input
+                    id="address-line2"
+                    value={addressLine2}
+                    placeholder="Bâtiment B, étage 3"
+                    onChange={(event) => setAddressLine2(event.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="space-y-2">
+                  <Label htmlFor="postal-code">Code postal</Label>
+                  <Input
+                    id="postal-code"
+                    value={postalCode}
+                    placeholder="75010"
+                    onChange={(event) => setPostalCode(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="city">Ville</Label>
+                  <Input
+                    id="city"
+                    value={city}
+                    placeholder="Paris"
+                    onChange={(event) => setCity(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="country">Pays</Label>
+                  <Input
+                    id="country"
+                    value={country}
+                    placeholder="France"
+                    onChange={(event) => setCountry(event.target.value)}
+                  />
+                </div>
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm text-muted-foreground">
+                Les changements s'appliqueront à la prochaine facture émise.
+              </div>
+              <div className="space-y-1 text-right">
+                <Button onClick={handleSaveBilling} disabled={savingBilling}>
+                  {savingBilling ? "Enregistrement..." : "Enregistrer"}
+                </Button>
+                {billingSuccess && <p className="text-xs text-green-600">{billingSuccess}</p>}
+                {billingError && <p className="text-xs text-destructive">{billingError}</p>}
+              </div>
+            </CardFooter>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Moyen de paiement</CardTitle>
+              <CardDescription>
+                Enregistrez votre carte pour assurer la continuité du service.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="card-brand">Type de carte</Label>
+                  <Input
+                    id="card-brand"
+                    value={cardBrand}
+                    placeholder="Visa, Mastercard..."
+                    onChange={(event) => setCardBrand(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="card-last4">Quatre derniers chiffres</Label>
+                  <Input
+                    id="card-last4"
+                    maxLength={4}
+                    value={cardLast4}
+                    placeholder="1234"
+                    onChange={(event) => setCardLast4(event.target.value.replace(/[^0-9]/g, ""))}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="card-exp-month">Mois d'expiration</Label>
+                  <Input
+                    id="card-exp-month"
+                    maxLength={2}
+                    value={cardExpMonth}
+                    placeholder="08"
+                    onChange={(event) => setCardExpMonth(event.target.value.replace(/[^0-9]/g, ""))}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="card-exp-year">Année d'expiration</Label>
+                  <Input
+                    id="card-exp-year"
+                    maxLength={4}
+                    value={cardExpYear}
+                    placeholder="2026"
+                    onChange={(event) => setCardExpYear(event.target.value.replace(/[^0-9]/g, ""))}
+                  />
+                </div>
+              </div>
+
+              {currentOrganization.billing?.paymentMethod && (
+                <div className="rounded-md border bg-muted/40 p-4 text-sm">
+                  <p className="font-medium">Carte actuelle</p>
+                  <p className="text-muted-foreground">
+                    {currentOrganization.billing.paymentMethod.brand} se terminant par {" "}
+                    {currentOrganization.billing.paymentMethod.last4} · expiration {" "}
+                    {currentOrganization.billing.paymentMethod.expMonth.toString().padStart(2, "0")}/
+                    {currentOrganization.billing.paymentMethod.expYear}
+                  </p>
+                </div>
+              )}
+            </CardContent>
+            <CardFooter className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm text-muted-foreground">
+                Les paiements sont sécurisés via notre prestataire Stripe.
+              </div>
+              <div className="space-y-1 text-right">
+                <Button onClick={handleSavePaymentMethod} disabled={savingPayment}>
+                  {savingPayment ? "Enregistrement..." : "Mettre à jour"}
+                </Button>
+                {paymentSuccess && <p className="text-xs text-green-600">{paymentSuccess}</p>}
+                {paymentError && <p className="text-xs text-destructive">{paymentError}</p>}
+              </div>
+            </CardFooter>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Historique des factures</CardTitle>
+              <CardDescription>
+                Téléchargez vos factures passées et vérifiez leur statut.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Période</TableHead>
+                    <TableHead>Montant</TableHead>
+                    <TableHead>Statut</TableHead>
+                    <TableHead>Émise le</TableHead>
+                    <TableHead className="text-right">Document</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {invoices.map((invoice) => (
+                    <TableRow key={invoice.id}>
+                      <TableCell className="font-medium">{invoice.label}</TableCell>
+                      <TableCell>
+                        {formatter.format(invoice.amount)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={
+                            invoice.status === "paid"
+                              ? "default"
+                              : invoice.status === "due"
+                              ? "secondary"
+                              : "outline"
+                          }
+                        >
+                          {STATUS_LABELS[invoice.status]}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        {new Date(invoice.issuedAt).toLocaleDateString("fr-FR")}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button variant="link" size="sm" asChild>
+                          <Link href={invoice.downloadUrl ?? "#"}>Télécharger</Link>
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Plan actuel</CardTitle>
+              <CardDescription>
+                Vous êtes sur le plan {PLAN_LABELS[currentOrganization.plan]}. Sélectionnez un autre plan pour changer d'offre.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-3">
+                {PRICING_PLANS.map((plan) => {
+                  const isCurrent = plan.id === currentOrganization.plan;
+                  const isLoading = updatingPlan === plan.id;
+
+                  return (
+                    <div
+                      key={plan.id}
+                      className={`rounded-lg border p-4 ${
+                        isCurrent ? "border-primary/60 bg-primary/5" : "border-border"
+                      }`}
+                    >
+                      <div className="flex flex-col gap-2">
+                        <div className="flex items-center justify-between gap-2">
+                          <div>
+                            <p className="font-semibold">{plan.name}</p>
+                            <p className="text-sm text-muted-foreground">{plan.description}</p>
+                          </div>
+                          {plan.highlight && <Badge variant="secondary">Populaire</Badge>}
+                        </div>
+                        <p className="text-lg font-semibold">{plan.price}</p>
+                        <ul className="list-disc space-y-1 pl-4 text-sm text-muted-foreground">
+                          {plan.perks.map((perk) => (
+                            <li key={perk}>{perk}</li>
+                          ))}
+                        </ul>
+                        <Button
+                          disabled={isCurrent || isLoading}
+                          onClick={() => handleSelectPlan(plan.id as PlanId)}
+                          variant={isCurrent ? "secondary" : "default"}
+                        >
+                          {isCurrent
+                            ? "Plan actuel"
+                            : isLoading
+                            ? "Mise à jour..."
+                            : `Choisir ${plan.name}`}
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+              {planSuccess && <p className="text-sm text-green-600">{planSuccess}</p>}
+              {planError && <p className="text-sm text-destructive">{planError}</p>}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Renouvellement</CardTitle>
+              <CardDescription>
+                Votre abonnement se renouvellera automatiquement à la date indiquée.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Prochaine échéance</span>
+                <span className="font-medium">
+                  {currentOrganization.billing?.planRenewalDate
+                    ? new Date(currentOrganization.billing.planRenewalDate).toLocaleDateString("fr-FR")
+                    : "Non défini"}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Statut</span>
+                <Badge variant="outline">Actif</Badge>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Mode de paiement</span>
+                <span>
+                  {currentOrganization.billing?.paymentMethod
+                    ? `${currentOrganization.billing.paymentMethod.brand} ·••${currentOrganization.billing.paymentMethod.last4}`
+                    : "Aucun enregistré"}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, Building2, CreditCard, Plug, Settings as SettingsIcon, UserCog, Users } from "lucide-react";
+
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { PLAN_LABELS } from "@/lib/plans";
+
+const SETTINGS_SECTIONS = [
+  {
+    title: "Paramètres du compte",
+    description:
+      "Gérez vos informations personnelles, vos préférences linguistiques et vos notifications.",
+    href: "/dashboard/settings/account",
+    icon: UserCog,
+    actionLabel: "Configurer",
+  },
+  {
+    title: "Organisation",
+    description:
+      "Mettez à jour le profil de l'organisation, les canaux de support et les options de conformité.",
+    href: "/dashboard/settings/organization",
+    icon: Building2,
+    actionLabel: "Modifier",
+  },
+  {
+    title: "Équipe",
+    description:
+      "Invitez de nouveaux membres, gérez les rôles et surveillez la capacité de votre plan.",
+    href: "/dashboard/settings/team",
+    icon: Users,
+    actionLabel: "Gérer",
+  },
+  {
+    title: "Abonnement & facturation",
+    description:
+      "Mettez à niveau votre plan, mettez à jour les informations de facturation et accédez aux factures.",
+    href: "/dashboard/settings/billing",
+    icon: CreditCard,
+    actionLabel: "Ouvrir",
+  },
+  {
+    title: "Intégrations",
+    description:
+      "Connectez vos comptes sociaux et outils marketing pour automatiser vos flux de travail.",
+    href: "/dashboard/settings/integrations",
+    icon: Plug,
+    actionLabel: "Configurer",
+  },
+  {
+    title: "Préférences globales",
+    description:
+      "Ajustez les politiques de publication, les validations automatiques et l'expérience équipe.",
+    href: "/dashboard/settings/organization#policies",
+    icon: SettingsIcon,
+    actionLabel: "Ajuster",
+  },
+];
+
+export default function SettingsOverviewPage() {
+  const { currentOrganization } = useAuth();
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold">Centre de paramètres</h1>
+        <p className="text-sm text-muted-foreground">
+          Centralisez la gestion de votre compte, de votre organisation et de votre abonnement.
+        </p>
+      </div>
+
+      <Separator />
+
+      {currentOrganization && (
+        <Card>
+          <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <CardTitle>Résumé de l'abonnement</CardTitle>
+              <CardDescription>
+                Vous êtes actuellement sur le plan {""}
+                <span className="capitalize">
+                  {PLAN_LABELS[currentOrganization.plan]}
+                </span>
+                .
+              </CardDescription>
+            </div>
+            <Badge variant="outline" className="capitalize">
+              {PLAN_LABELS[currentOrganization.plan]}
+            </Badge>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-3">
+            <div>
+              <p className="text-xs uppercase text-muted-foreground">Organisation</p>
+              <p className="font-medium">{currentOrganization.name}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase text-muted-foreground">Renouvellement</p>
+              <p className="font-medium">
+                {currentOrganization.billing?.planRenewalDate
+                  ? new Date(currentOrganization.billing.planRenewalDate).toLocaleDateString()
+                  : "À définir"}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs uppercase text-muted-foreground">Membres</p>
+              <p className="font-medium">{currentOrganization.members.length}</p>
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-sm text-muted-foreground">
+              Besoin de plus de capacité ou de fonctionnalités avancées ?
+            </div>
+            <Button asChild>
+              <Link href="/dashboard/settings/billing" className="inline-flex items-center gap-2">
+                Gérer l'abonnement
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {SETTINGS_SECTIONS.map((section) => (
+          <Card key={section.href} className="flex flex-col">
+            <CardHeader className="flex flex-row items-start gap-4">
+              <div className="rounded-lg border bg-muted/40 p-2">
+                <section.icon className="h-5 w-5" />
+              </div>
+              <div>
+                <CardTitle className="text-lg">{section.title}</CardTitle>
+                <CardDescription>{section.description}</CardDescription>
+              </div>
+            </CardHeader>
+            <CardFooter className="mt-auto">
+              <Button asChild variant="ghost" className="ml-auto inline-flex items-center gap-2">
+                <Link href={section.href}>
+                  {section.actionLabel}
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -47,7 +47,6 @@ export function UserMenu({ user }: UserMenuProps) {
       console.error("Logout error:", error);
     }
   };
-  console.log(user);
   const router = useRouter();
   const avatarUrl = getAvatarUrl(user.avatar);
 
@@ -106,20 +105,26 @@ export function UserMenu({ user }: UserMenuProps) {
           <User className="mr-2 h-4 w-4" />
           Profil
         </DropdownMenuItem>
-        <DropdownMenuItem>
+        <DropdownMenuItem onClick={() => router.push("/dashboard/settings/account")}>
           <Settings className="mr-2 h-4 w-4" />
           Paramètres du compte
         </DropdownMenuItem>
-        <DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() =>
+            router.push("/dashboard/settings/account#notifications")
+          }
+        >
           <Bell className="mr-2 h-4 w-4" />
           Notifications
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => router.push("/dashboard/settings/billing")}
+        >
           <CreditCard className="mr-2 h-4 w-4" />
           Facturation
         </DropdownMenuItem>
-        <DropdownMenuItem>
+        <DropdownMenuItem onClick={() => router.push("/dashboard/support")}>
           <HelpCircle className="mr-2 h-4 w-4" />
           Aide & Support
         </DropdownMenuItem>

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ interface AuthContextType {
     plan?: "starter" | "pro" | "enterprise",
   ) => Promise<Organization>;
   updateCurrentOrganization: (data: Partial<Organization>) => Promise<void>;
+  updateUserProfile: (data: Partial<User>) => Promise<void>;
   refreshUser: () => Promise<void>;
 }
 
@@ -113,6 +114,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       await refreshUser();
     } catch (error) {
       console.error("Erreur lors de la mise à jour de l'organisation :", error);
+      throw error;
+    }
+  };
+
+  const updateUserProfile = async (data: Partial<User>) => {
+    if (!user) return;
+
+    try {
+      await authService.updateUserProfile(user.$id, data);
+      await refreshUser();
+    } catch (error) {
+      console.error("Erreur lors de la mise à jour du profil :", error);
+      throw error;
     }
   };
 
@@ -133,6 +147,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         switchOrganization,
         createOrganization,
         updateCurrentOrganization,
+        updateUserProfile,
         refreshUser,
       }}
     >

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -9,6 +9,53 @@ import { ID, Query } from "appwrite";
 import type { Models } from "appwrite";
 import { getPlanLimit } from "./plans";
 
+export interface CommunicationPreferences {
+  productUpdates: boolean;
+  weeklySummary: boolean;
+  securityAlerts: boolean;
+}
+
+export interface BillingContact {
+  companyName?: string;
+  contactName?: string;
+  email?: string;
+  addressLine1?: string;
+  addressLine2?: string;
+  city?: string;
+  postalCode?: string;
+  country?: string;
+  vatNumber?: string;
+  purchaseOrder?: string;
+}
+
+export interface PaymentMethodDetails {
+  brand: string;
+  last4: string;
+  expMonth: number;
+  expYear: number;
+  isDefault?: boolean;
+}
+
+export type InvoiceStatus = "paid" | "due" | "failed" | "void";
+
+export interface InvoiceRecord {
+  id: string;
+  label: string;
+  amount: number;
+  currency: string;
+  status: InvoiceStatus;
+  issuedAt: string;
+  downloadUrl?: string;
+}
+
+export interface BillingSettings {
+  billingEmail?: string;
+  contact?: BillingContact;
+  paymentMethod?: PaymentMethodDetails | null;
+  planRenewalDate?: string;
+  invoices?: InvoiceRecord[];
+}
+
 export interface User {
   $id: string;
   name: string;
@@ -16,6 +63,9 @@ export interface User {
   avatar?: string;
   organizations: string[];
   currentOrganization?: string;
+  language?: string;
+  timezone?: string;
+  communicationPreferences?: CommunicationPreferences;
 }
 
 export interface SupportCenterConfig {
@@ -127,6 +177,7 @@ export interface Organization {
   brandGuidelines?: BrandGuideline[];
   audiencePersonas?: AudiencePersona[];
   aiModelConfigs?: AIModelConfig[];
+  billing?: BillingSettings;
 }
 
 export class AuthService {
@@ -197,6 +248,13 @@ export class AuthService {
         {
           ...data,
           createdAt: new Date().toISOString(),
+          language: "fr",
+          timezone: "Europe/Paris",
+          communicationPreferences: {
+            productUpdates: true,
+            weeklySummary: true,
+            securityAlerts: true,
+          },
         }
       );
     } catch (error) {
@@ -265,6 +323,19 @@ export class AuthService {
             allowCustomRegion: plan === "enterprise",
             complianceArtifacts: [],
             requestContactEmail: "",
+          },
+          billing: {
+            billingEmail: user.email,
+            contact: {
+              companyName: name,
+              contactName: user.name,
+              email: user.email,
+            },
+            paymentMethod: null,
+            planRenewalDate: new Date(
+              Date.now() + 30 * 24 * 60 * 60 * 1000,
+            ).toISOString(),
+            invoices: [],
           },
           ideaBacklog: [],
           editorialCalendar: [],

--- a/lib/navigation-data.ts
+++ b/lib/navigation-data.ts
@@ -9,10 +9,12 @@ import {
   Home,
   ImageIcon,
   Lightbulb,
+  CreditCard,
+  Plug,
+  UserCog,
   Mail,
   MessageSquare,
   Palette,
-  LifeBuoy,
   Settings,
   Users,
   Zap,
@@ -259,6 +261,16 @@ export const managementTools: NavigationItem[] = [
 
 export const organizationSettings: NavigationItem[] = [
   {
+    title: "Vue d'ensemble",
+    url: "/dashboard/settings",
+    icon: Settings,
+  },
+  {
+    title: "Paramètres du compte",
+    url: "/dashboard/settings/account",
+    icon: UserCog,
+  },
+  {
     title: "Organization Settings",
     url: "/dashboard/settings/organization",
     icon: Building2,
@@ -269,13 +281,13 @@ export const organizationSettings: NavigationItem[] = [
     icon: Users,
   },
   {
-    title: "Integrations",
-    url: "/dashboard/settings/integrations",
-    icon: Settings,
+    title: "Abonnement & Facturation",
+    url: "/dashboard/settings/billing",
+    icon: CreditCard,
   },
   {
-    title: "Support Center",
-    url: "/dashboard/support",
-    icon: LifeBuoy,
+    title: "Integrations",
+    url: "/dashboard/settings/integrations",
+    icon: Plug,
   },
 ];


### PR DESCRIPTION
## Summary
- introduce a settings overview hub with quick links to key configuration areas
- add dedicated account and billing pages with editable user preferences, payment data, and plan management
- expand auth models and navigation to expose billing data and remove duplicate support links

## Testing
- npm run lint *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68d7baca51a88323930d91981ada1c76